### PR TITLE
[5-1] 고객 문의 리스트 조회

### DIFF
--- a/src/main/java/com/prography/zone_2_be/domain/customerinquiry/controller/CustomerInquiryController.java
+++ b/src/main/java/com/prography/zone_2_be/domain/customerinquiry/controller/CustomerInquiryController.java
@@ -1,0 +1,35 @@
+package com.prography.zone_2_be.domain.customerinquiry.controller;
+
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.prography.zone_2_be.domain.customerinquiry.dto.CustomerInquiryFindAllResponse;
+import com.prography.zone_2_be.domain.customerinquiry.service.CustomerInquiryService;
+import com.prography.zone_2_be.global.constant.CommonConst;
+import com.prography.zone_2_be.global.response.ApiResponse;
+import com.prography.zone_2_be.global.response.SliceResponse;
+
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequestMapping("/api/v1/customer-inquiry")
+@RequiredArgsConstructor
+public class CustomerInquiryController {
+
+	private final CustomerInquiryService customerInquiryService;
+
+	@GetMapping
+	public ResponseEntity<ApiResponse<SliceResponse<CustomerInquiryFindAllResponse>>> findAllCustomerInquiry(
+		@RequestParam(defaultValue = "0") int pageNumber) {
+		Pageable pageable = PageRequest.of(pageNumber, CommonConst.DEFAULT_PAGE_SIZE);
+		SliceResponse<CustomerInquiryFindAllResponse> response = customerInquiryService.findAllCustomerInquiry(
+			pageable);
+
+		return ApiResponse.success(response);
+	}
+}

--- a/src/main/java/com/prography/zone_2_be/domain/customerinquiry/dto/CustomerInquiryFindAllResponse.java
+++ b/src/main/java/com/prography/zone_2_be/domain/customerinquiry/dto/CustomerInquiryFindAllResponse.java
@@ -1,0 +1,29 @@
+package com.prography.zone_2_be.domain.customerinquiry.dto;
+
+import com.prography.zone_2_be.domain.customerinquiry.entity.CustomerInquiry;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class CustomerInquiryFindAllResponse {
+
+	private Long id;
+	private String title;
+	private boolean isPinned;
+
+	@Builder
+	private CustomerInquiryFindAllResponse(Long id, String title, boolean isPinned) {
+		this.id = id;
+		this.title = title;
+		this.isPinned = isPinned;
+	}
+
+	public static CustomerInquiryFindAllResponse from(CustomerInquiry customerInquiry) {
+		return CustomerInquiryFindAllResponse.builder()
+			.id(customerInquiry.getId())
+			.title(customerInquiry.getTitle())
+			.isPinned(customerInquiry.isPinned())
+			.build();
+	}
+}

--- a/src/main/java/com/prography/zone_2_be/domain/customerinquiry/entity/CustomerInquiry.java
+++ b/src/main/java/com/prography/zone_2_be/domain/customerinquiry/entity/CustomerInquiry.java
@@ -1,0 +1,52 @@
+package com.prography.zone_2_be.domain.customerinquiry.entity;
+
+import com.prography.zone_2_be.global.entity.UpdatableEntity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class CustomerInquiry extends UpdatableEntity {
+
+	@Column(nullable = false, length = 128)
+	private String title;
+
+	@Column(nullable = false, columnDefinition = "TEXT")
+	private String content;
+
+	@Column(nullable = false)
+	private boolean isPinned;
+
+	@Builder
+	public CustomerInquiry(String title, String content, boolean isPinned) {
+		this.title = title;
+		this.content = content;
+		this.isPinned = isPinned;
+	}
+
+	public static CustomerInquiry of(String title, String content) {
+		return CustomerInquiry.builder()
+			.title(title)
+			.content(content)
+			.isPinned(false)
+			.build();
+	}
+
+	public void pin() {
+		if (!this.isPinned) {
+			this.isPinned = true;
+		}
+	}
+
+	public void unpin() {
+		if (this.isPinned) {
+			this.isPinned = false;
+		}
+	}
+}

--- a/src/main/java/com/prography/zone_2_be/domain/customerinquiry/repository/CustomerInquiryRepository.java
+++ b/src/main/java/com/prography/zone_2_be/domain/customerinquiry/repository/CustomerInquiryRepository.java
@@ -1,0 +1,14 @@
+package com.prography.zone_2_be.domain.customerinquiry.repository;
+
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import com.prography.zone_2_be.domain.customerinquiry.entity.CustomerInquiry;
+
+@Repository
+public interface CustomerInquiryRepository extends JpaRepository<CustomerInquiry, Long> {
+
+	Slice<CustomerInquiry> findAllByOrderByIsPinnedDescCreatedAtDesc(Pageable pageable);
+}

--- a/src/main/java/com/prography/zone_2_be/domain/customerinquiry/service/CustomerInquiryService.java
+++ b/src/main/java/com/prography/zone_2_be/domain/customerinquiry/service/CustomerInquiryService.java
@@ -1,0 +1,25 @@
+package com.prography.zone_2_be.domain.customerinquiry.service;
+
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.stereotype.Service;
+
+import com.prography.zone_2_be.domain.customerinquiry.dto.CustomerInquiryFindAllResponse;
+import com.prography.zone_2_be.domain.customerinquiry.repository.CustomerInquiryRepository;
+import com.prography.zone_2_be.global.response.SliceResponse;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class CustomerInquiryService {
+
+	private final CustomerInquiryRepository customerInquiryRepository;
+
+	public SliceResponse<CustomerInquiryFindAllResponse> findAllCustomerInquiry(Pageable pageable) {
+		Slice<CustomerInquiryFindAllResponse> slice = customerInquiryRepository.findAllByOrderByIsPinnedDescCreatedAtDesc(
+				pageable)
+			.map(CustomerInquiryFindAllResponse::from);
+		return SliceResponse.from(slice);
+	}
+}

--- a/src/test/java/com/prography/zone_2_be/domain/customerinquiry/repository/CustomerInquiryRepositoryTest.java
+++ b/src/test/java/com/prography/zone_2_be/domain/customerinquiry/repository/CustomerInquiryRepositoryTest.java
@@ -1,0 +1,86 @@
+package com.prography.zone_2_be.domain.customerinquiry.repository;
+
+import static org.assertj.core.api.Assertions.*;
+
+import java.util.List;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.test.context.ActiveProfiles;
+
+import com.prography.zone_2_be.domain.customerinquiry.entity.CustomerInquiry;
+import com.prography.zone_2_be.global.constant.CommonConst;
+
+@SpringBootTest
+@ActiveProfiles("test")
+class CustomerInquiryRepositoryTest {
+
+	@Autowired
+	private CustomerInquiryRepository customerInquiryRepository;
+
+	@Test
+	@DisplayName("Pinned=true 그룹만 추출해서 createdAt 내림차순인지 검증")
+	void pinnedGroupOrdering() {
+		List<CustomerInquiry> all = customerInquiryRepository
+			.findAllByOrderByIsPinnedDescCreatedAtDesc(PageRequest.of(0, CommonConst.DEFAULT_PAGE_SIZE))
+			.getContent();
+
+		List<CustomerInquiry> pinned = all.stream()
+			.filter(CustomerInquiry::isPinned)
+			.toList();
+
+		for (int i = 0; i < pinned.size() - 1; i++) {
+			Long current = pinned.get(i).getCreatedAt();
+			Long next = pinned.get(i + 1).getCreatedAt();
+			assertThat(current)
+				.as("Pinned 그룹 내에서 createdAt 내림차순이 유지되어야 한다")
+				.isGreaterThanOrEqualTo(next);
+		}
+	}
+
+	@Test
+	@DisplayName("Pinned=false 그룹만 추출해서 createdAt 내림차순인지 검증")
+	void normalGroupOrdering() {
+		List<CustomerInquiry> all = customerInquiryRepository
+			.findAllByOrderByIsPinnedDescCreatedAtDesc(PageRequest.of(0, CommonConst.DEFAULT_PAGE_SIZE))
+			.getContent();
+
+		List<CustomerInquiry> normal = all.stream()
+			.filter(ci -> !ci.isPinned())
+			.toList();
+
+		for (int i = 0; i < normal.size() - 1; i++) {
+			Long current = normal.get(i).getCreatedAt();
+			Long next = normal.get(i + 1).getCreatedAt();
+			assertThat(current)
+				.as("Normal 그룹 내에서 createdAt 내림차순이 유지되어야 한다")
+				.isGreaterThanOrEqualTo(next);
+		}
+	}
+
+	@Test
+	@DisplayName("전체 리스트에서 pinned 그룹이 앞쪽에 몰려 있는지 확인")
+	void pinnedGroupIsFront() {
+		List<CustomerInquiry> all = customerInquiryRepository
+			.findAllByOrderByIsPinnedDescCreatedAtDesc(PageRequest.of(0, CommonConst.DEFAULT_PAGE_SIZE))
+			.getContent();
+
+		List<CustomerInquiry> pinned = all.stream()
+			.filter(CustomerInquiry::isPinned)
+			.toList();
+
+		for (int i = 0; i < pinned.size(); i++) {
+			assertThat(all.get(i).isPinned())
+				.as("첫 %d개 항목은 모두 pinned=true여야 한다", pinned.size())
+				.isTrue();
+		}
+		for (int i = pinned.size(); i < all.size(); i++) {
+			assertThat(all.get(i).isPinned())
+				.as("pinned 그룹이 끝난 이후에는 모두 pinned=false여야 한다")
+				.isFalse();
+		}
+	}
+}


### PR DESCRIPTION
## 📝 작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요.  
- CustomerInquiry 엔티티 구현
- 조회용 DTO(CustomerInquiryFindAllResponse) 구현
- CustomerInquiryRepository에 정렬용 메서드(findAllByOrderByIsPinnedDescCreatedAtDesc) 추가
- NCustomerInquiryService에서 정렬된 데이터 조회 후 DTO 매핑 로직 작성
- CustomerInquiryController 구현
- Repository 정렬 로직 검증을 위한 테스트 코드 작성