### PR TITLE
[3-2] 약관 버전 별 조회

### DIFF
--- a/src/main/java/com/prography/zone_2_be/domain/term/controller/TermController.java
+++ b/src/main/java/com/prography/zone_2_be/domain/term/controller/TermController.java
@@ -5,9 +5,12 @@ import java.util.List;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.prography.zone_2_be.domain.term.dto.TermFindAllResponse;
+import com.prography.zone_2_be.domain.term.dto.TermFindAllVersionResponse;
+import com.prography.zone_2_be.domain.term.entity.TermType;
 import com.prography.zone_2_be.domain.term.service.TermService;
 import com.prography.zone_2_be.global.response.ApiResponse;
 
@@ -24,5 +27,12 @@ public class TermController {
 	public ResponseEntity<ApiResponse<List<TermFindAllResponse>>> findAllTerm() {
 		List<TermFindAllResponse> terms = termService.findAllTerm();
 		return ApiResponse.success(terms);
+	}
+	
+	@GetMapping("/versions")
+	public ResponseEntity<ApiResponse<List<TermFindAllVersionResponse>>> findAllTermVersions(
+		@RequestParam(required = false) TermType termType) {
+		List<TermFindAllVersionResponse> response = termService.findAllTermVersion(termType);
+		return ApiResponse.success(response);
 	}
 }

--- a/src/main/java/com/prography/zone_2_be/domain/term/controller/TermController.java
+++ b/src/main/java/com/prography/zone_2_be/domain/term/controller/TermController.java
@@ -4,12 +4,14 @@ import java.util.List;
 
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.prography.zone_2_be.domain.term.dto.TermFindAllResponse;
 import com.prography.zone_2_be.domain.term.dto.TermFindAllVersionResponse;
+import com.prography.zone_2_be.domain.term.dto.TermFindResponse;
 import com.prography.zone_2_be.domain.term.entity.TermType;
 import com.prography.zone_2_be.domain.term.service.TermService;
 import com.prography.zone_2_be.global.response.ApiResponse;
@@ -28,11 +30,18 @@ public class TermController {
 		List<TermFindAllResponse> terms = termService.findAllTerm();
 		return ApiResponse.success(terms);
 	}
-	
+
 	@GetMapping("/versions")
 	public ResponseEntity<ApiResponse<List<TermFindAllVersionResponse>>> findAllTermVersions(
 		@RequestParam(required = false) TermType termType) {
 		List<TermFindAllVersionResponse> response = termService.findAllTermVersion(termType);
+		return ApiResponse.success(response);
+	}
+
+	@GetMapping("/{termId}")
+	public ResponseEntity<ApiResponse<TermFindResponse>> findTerm(
+		@PathVariable("termId") Long termId) {
+		TermFindResponse response = termService.findTerm(termId);
 		return ApiResponse.success(response);
 	}
 }

--- a/src/main/java/com/prography/zone_2_be/domain/term/dto/TermFindAllVersionResponse.java
+++ b/src/main/java/com/prography/zone_2_be/domain/term/dto/TermFindAllVersionResponse.java
@@ -1,0 +1,26 @@
+package com.prography.zone_2_be.domain.term.dto;
+
+import com.prography.zone_2_be.domain.term.entity.Term;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class TermFindAllVersionResponse {
+
+	private Long id;
+	private Long createdAt;
+
+	@Builder
+	private TermFindAllVersionResponse(Long id, Long createdAt) {
+		this.id = id;
+		this.createdAt = createdAt;
+	}
+
+	public static TermFindAllVersionResponse from(Term term) {
+		return TermFindAllVersionResponse.builder()
+			.id(term.getId())
+			.createdAt(term.getCreatedAt())
+			.build();
+	}
+}

--- a/src/main/java/com/prography/zone_2_be/domain/term/dto/TermFindResponse.java
+++ b/src/main/java/com/prography/zone_2_be/domain/term/dto/TermFindResponse.java
@@ -1,0 +1,23 @@
+package com.prography.zone_2_be.domain.term.dto;
+
+import com.prography.zone_2_be.domain.term.entity.Term;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class TermFindResponse {
+
+	private String content;
+
+	@Builder
+	private TermFindResponse(String content) {
+		this.content = content;
+	}
+
+	public static TermFindResponse from(Term term) {
+		return TermFindResponse.builder()
+			.content(term.getContent())
+			.build();
+	}
+}

--- a/src/main/java/com/prography/zone_2_be/domain/term/repository/TermRepository.java
+++ b/src/main/java/com/prography/zone_2_be/domain/term/repository/TermRepository.java
@@ -8,9 +8,17 @@ import org.springframework.stereotype.Repository;
 
 import com.prography.zone_2_be.domain.term.entity.Term;
 import com.prography.zone_2_be.domain.term.entity.TermType;
+import com.prography.zone_2_be.global.error.ErrorCode;
+import com.prography.zone_2_be.global.exception.CustomException;
 
 @Repository
 public interface TermRepository extends JpaRepository<Term, Long> {
+
+	//default 메서드
+	default Term findByIdOrThrow(Long termId) {
+		return findById(termId)
+			.orElseThrow(() -> new CustomException(ErrorCode.TERM_NOT_FOUND));
+	}
 
 	@Query(value = """
 		SELECT t.*

--- a/src/main/java/com/prography/zone_2_be/domain/term/repository/TermRepository.java
+++ b/src/main/java/com/prography/zone_2_be/domain/term/repository/TermRepository.java
@@ -7,6 +7,7 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 import com.prography.zone_2_be.domain.term.entity.Term;
+import com.prography.zone_2_be.domain.term.entity.TermType;
 
 @Repository
 public interface TermRepository extends JpaRepository<Term, Long> {
@@ -21,4 +22,6 @@ public interface TermRepository extends JpaRepository<Term, Long> {
 		) m ON t.term_type = m.term_type AND t.created_at = m.max_created
 		""", nativeQuery = true)
 	List<Term> findLatestTermsGroupedByType();
+
+	List<Term> findAllByTermTypeOrderByCreatedAtDesc(TermType type);
 }

--- a/src/main/java/com/prography/zone_2_be/domain/term/service/TermService.java
+++ b/src/main/java/com/prography/zone_2_be/domain/term/service/TermService.java
@@ -6,6 +6,8 @@ import org.springframework.stereotype.Service;
 
 import com.prography.zone_2_be.domain.term.dto.TermFindAllResponse;
 import com.prography.zone_2_be.domain.term.dto.TermFindAllVersionResponse;
+import com.prography.zone_2_be.domain.term.dto.TermFindResponse;
+import com.prography.zone_2_be.domain.term.entity.Term;
 import com.prography.zone_2_be.domain.term.entity.TermType;
 import com.prography.zone_2_be.domain.term.repository.TermRepository;
 
@@ -29,5 +31,10 @@ public class TermService {
 			.stream()
 			.map(TermFindAllVersionResponse::from)
 			.toList();
+	}
+
+	public TermFindResponse findTerm(Long termId) {
+		Term term = termRepository.findByIdOrThrow(termId);
+		return TermFindResponse.from(term);
 	}
 }

--- a/src/main/java/com/prography/zone_2_be/domain/term/service/TermService.java
+++ b/src/main/java/com/prography/zone_2_be/domain/term/service/TermService.java
@@ -5,6 +5,8 @@ import java.util.List;
 import org.springframework.stereotype.Service;
 
 import com.prography.zone_2_be.domain.term.dto.TermFindAllResponse;
+import com.prography.zone_2_be.domain.term.dto.TermFindAllVersionResponse;
+import com.prography.zone_2_be.domain.term.entity.TermType;
 import com.prography.zone_2_be.domain.term.repository.TermRepository;
 
 import lombok.RequiredArgsConstructor;
@@ -19,6 +21,13 @@ public class TermService {
 		return termRepository.findLatestTermsGroupedByType()
 			.stream()
 			.map(TermFindAllResponse::from)
+			.toList();
+	}
+
+	public List<TermFindAllVersionResponse> findAllTermVersion(TermType termType) {
+		return termRepository.findAllByTermTypeOrderByCreatedAtDesc(termType)
+			.stream()
+			.map(TermFindAllVersionResponse::from)
 			.toList();
 	}
 }

--- a/src/main/java/com/prography/zone_2_be/global/error/ErrorCode.java
+++ b/src/main/java/com/prography/zone_2_be/global/error/ErrorCode.java
@@ -19,6 +19,9 @@ public enum ErrorCode {
 	// Notice 에러 4100번대
 	NOTICE_NOT_FOUND(HttpStatus.NOT_FOUND, 4100, "해당 ID의 공지사항을 찾을 수 없습니다."),
 
+	// Term 에러 4200번대
+	TERM_NOT_FOUND(HttpStatus.NOT_FOUND, 4200, "해당 ID의 약관을 찾을 수 없습니다."),
+
 	// Global Server 에러
 	DEFAULT_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, 5000, "서버에서 알 수 없는 오류 발생.");
 


### PR DESCRIPTION
## 📝 작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요.

* **TermController**

  * `GET /api/v1/term/versions` 엔드포인트 추가
  * `GET /api/v1/term/{termId}` 엔드포인트 추가

* **DTO 추가**

  * `TermFindAllVersionResponse`

    * 약관 버전 목록용 (id, createdAt)
  * `TermFindResponse`

    * 단건 조회용 (content)

* **TermRepository**

  * `default Term findByIdOrThrow(Long termId)`

    * 존재하지 않을 경우 `CustomException(ErrorCode.TERM_NOT_FOUND)` 발생
  * `List<Term> findAllByTermTypeOrderByCreatedAtDesc(TermType type)`

    * termType별 전체 버전 조회

* **TermService**

  * `findAllTermVersion(TermType termType)`

    * Repository 호출 후 DTO 매핑
  * `findTerm(Long termId)`

    * `findByIdOrThrow`로 조회 후 DTO 매핑

* **ErrorCode 업데이트**

  * `TERM_NOT_FOUND(HttpStatus.NOT_FOUND, 4200, "해당 ID의 약관을 찾을 수 없습니다.")` 추가
