### PR TITLE
[3-3] 약관 동의

### DIFF
--- a/src/main/java/com/prography/zone_2_be/domain/term/agreement/controller/TermAgreementController.java
+++ b/src/main/java/com/prography/zone_2_be/domain/term/agreement/controller/TermAgreementController.java
@@ -1,0 +1,31 @@
+package com.prography.zone_2_be.domain.term.agreement.controller;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.prography.zone_2_be.domain.term.agreement.dto.TermAgreementSaveAllRequest;
+import com.prography.zone_2_be.domain.term.agreement.service.TermAgreementService;
+import com.prography.zone_2_be.global.response.ApiResponse;
+import com.prography.zone_2_be.global.utils.JwtUtil;
+
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequestMapping("/api/v1/term/agreement")
+@RequiredArgsConstructor
+public class TermAgreementController {
+
+	private final TermAgreementService termAgreementService;
+
+	@PostMapping("/agree-all")
+	public ResponseEntity<ApiResponse<Void>> saveAllTermAgreement(
+		@RequestBody @Valid TermAgreementSaveAllRequest request) {
+		String uuid = JwtUtil.getUuid();
+		termAgreementService.saveAllTermAgreement(uuid, request.getTermAgreementSaveRequests());
+		return ApiResponse.success();
+	}
+}

--- a/src/main/java/com/prography/zone_2_be/domain/term/agreement/dto/TermAgreementSaveAllRequest.java
+++ b/src/main/java/com/prography/zone_2_be/domain/term/agreement/dto/TermAgreementSaveAllRequest.java
@@ -1,0 +1,13 @@
+package com.prography.zone_2_be.domain.term.agreement.dto;
+
+import java.util.List;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class TermAgreementSaveAllRequest {
+	private List<TermAgreementSaveRequest> termAgreementSaveRequests;
+}

--- a/src/main/java/com/prography/zone_2_be/domain/term/agreement/dto/TermAgreementSaveRequest.java
+++ b/src/main/java/com/prography/zone_2_be/domain/term/agreement/dto/TermAgreementSaveRequest.java
@@ -1,0 +1,12 @@
+package com.prography.zone_2_be.domain.term.agreement.dto;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class TermAgreementSaveRequest {
+	private Long termId;
+	private boolean agreed;
+}

--- a/src/main/java/com/prography/zone_2_be/domain/term/agreement/entity/TermAgreement.java
+++ b/src/main/java/com/prography/zone_2_be/domain/term/agreement/entity/TermAgreement.java
@@ -1,0 +1,41 @@
+package com.prography.zone_2_be.domain.term.agreement.entity;
+
+import com.prography.zone_2_be.domain.term.entity.Term;
+import com.prography.zone_2_be.domain.user.entity.User;
+import com.prography.zone_2_be.global.entity.BaseEntity;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class TermAgreement extends BaseEntity {
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "term_id", nullable = false)
+	private Term term;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "user_id", nullable = false)
+	private User user;
+
+	@Builder
+	private TermAgreement(Term term, User user) {
+		this.term = term;
+		this.user = user;
+	}
+
+	public static TermAgreement of(Term term, User user) {
+		return TermAgreement.builder()
+			.term(term)
+			.user(user)
+			.build();
+	}
+}

--- a/src/main/java/com/prography/zone_2_be/domain/term/agreement/repository/TermAgreementRepository.java
+++ b/src/main/java/com/prography/zone_2_be/domain/term/agreement/repository/TermAgreementRepository.java
@@ -1,10 +1,16 @@
 package com.prography.zone_2_be.domain.term.agreement.repository;
 
+import java.util.List;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 import com.prography.zone_2_be.domain.term.agreement.entity.TermAgreement;
+import com.prography.zone_2_be.domain.term.entity.Term;
+import com.prography.zone_2_be.domain.user.entity.User;
 
 @Repository
 public interface TermAgreementRepository extends JpaRepository<TermAgreement, Long> {
+	
+	List<TermAgreement> findByUserAndTermIn(User user, List<Term> terms);
 }

--- a/src/main/java/com/prography/zone_2_be/domain/term/agreement/repository/TermAgreementRepository.java
+++ b/src/main/java/com/prography/zone_2_be/domain/term/agreement/repository/TermAgreementRepository.java
@@ -1,0 +1,10 @@
+package com.prography.zone_2_be.domain.term.agreement.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import com.prography.zone_2_be.domain.term.agreement.entity.TermAgreement;
+
+@Repository
+public interface TermAgreementRepository extends JpaRepository<TermAgreement, Long> {
+}

--- a/src/main/java/com/prography/zone_2_be/domain/term/agreement/service/TermAgreementService.java
+++ b/src/main/java/com/prography/zone_2_be/domain/term/agreement/service/TermAgreementService.java
@@ -1,0 +1,71 @@
+package com.prography.zone_2_be.domain.term.agreement.service;
+
+import java.util.List;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.prography.zone_2_be.domain.term.agreement.dto.TermAgreementSaveRequest;
+import com.prography.zone_2_be.domain.term.agreement.entity.TermAgreement;
+import com.prography.zone_2_be.domain.term.agreement.repository.TermAgreementRepository;
+import com.prography.zone_2_be.domain.term.entity.Term;
+import com.prography.zone_2_be.domain.term.repository.TermRepository;
+import com.prography.zone_2_be.domain.user.entity.User;
+import com.prography.zone_2_be.domain.user.repository.UserRepository;
+import com.prography.zone_2_be.global.error.ErrorCode;
+import com.prography.zone_2_be.global.exception.CustomException;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class TermAgreementService {
+
+	private final TermAgreementRepository termAgreementRepository;
+	private final TermRepository termRepository;
+	private final UserRepository userRepository;
+
+	@Transactional
+	public void saveAllTermAgreement(String uuid, List<TermAgreementSaveRequest> requests) {
+		User user = userRepository.findByUuid(uuid).orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+
+		validateAllAgreed(requests);
+
+		List<Term> terms = findTermsByIds(extractTermIds(requests));
+
+		List<TermAgreement> newAgreements = createNewAgreements(user, terms);
+
+		termAgreementRepository.saveAll(newAgreements);
+	}
+
+	private void validateAllAgreed(List<TermAgreementSaveRequest> requests) {
+		if (!requests.stream().allMatch(TermAgreementSaveRequest::isAgreed)) {
+			throw new CustomException(ErrorCode.REQUIRED_TERMS_NOT_AGREED);
+		}
+	}
+
+	private List<Long> extractTermIds(List<TermAgreementSaveRequest> requests) {
+		return requests.stream()
+			.map(TermAgreementSaveRequest::getTermId)
+			.distinct()
+			.toList();
+	}
+
+	private List<Term> findTermsByIds(List<Long> termIds) {
+		List<Term> terms = termRepository.findAllById(termIds);
+		if (terms.size() != termIds.size()) {
+			throw new CustomException(ErrorCode.TERM_NOT_FOUND);
+		}
+		return terms;
+	}
+
+	private List<TermAgreement> createNewAgreements(User user, List<Term> terms) {
+		List<TermAgreement> existing = termAgreementRepository.findByUserAndTermIn(user, terms);
+
+		return terms.stream()
+			.filter(term -> existing.stream()
+				.noneMatch(agreement -> agreement.getTerm().getId().equals(term.getId())))
+			.map(term -> TermAgreement.of(term, user))
+			.toList();
+	}
+}

--- a/src/main/java/com/prography/zone_2_be/global/error/ErrorCode.java
+++ b/src/main/java/com/prography/zone_2_be/global/error/ErrorCode.java
@@ -22,6 +22,9 @@ public enum ErrorCode {
 	// Term 에러 4200번대
 	TERM_NOT_FOUND(HttpStatus.NOT_FOUND, 4200, "해당 ID의 약관을 찾을 수 없습니다."),
 
+	// TermAgreement 에러 4300번대
+	REQUIRED_TERMS_NOT_AGREED(HttpStatus.BAD_REQUEST, 4301, "필수 약관에 모두 동의해야 합니다."),
+
 	// Global Server 에러
 	DEFAULT_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, 5000, "서버에서 알 수 없는 오류 발생.");
 


### PR DESCRIPTION
## 📝 작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요.

### **TermAgreementController**

* `POST /api/v1/term/agreement/agree-all` 엔드포인트 추가
  → 사용자가 필수 약관 전체에 동의할 수 있도록 하는 API

### **DTO 추가**

* `TermAgreementSaveAllRequest`

  * 약관 동의 요청의 전체 요청 바디 구조
  * 내부에 `List<TermAgreementSaveRequest>` 포함

* `TermAgreementSaveRequest`

  * 개별 약관 ID와 `agreed` 여부 포함

### **TermAgreementRepository**

* `List<TermAgreement> findByUserAndTermIn(User user, List<Term> terms)` 메서드 추가
  → 사용자와 약관 목록 기준으로 기존 동의 항목 조회 가능

### **TermAgreementService**

* `saveAllTermAgreement(String uuid, List<TermAgreementSaveRequest> requests)`

  * 유저 UUID 기반 조회
  * 모든 항목에 `agreed == true`인지 유효성 검증
  * termId 리스트 → 약관 엔티티 조회
  * 이미 동의한 약관 제외 후 새로운 동의만 저장
  * 내부 로직은 단위 메서드(`validateAllAgreed`, `findTermsByIds`, `createNewAgreements`)로 분리하여 가독성과 재사용성 향상

### **ErrorCode 업데이트**

* `REQUIRED_TERMS_NOT_AGREED(HttpStatus.BAD_REQUEST, 4201, "필수 약관 전체에 동의해야 합니다.")`
  → 동의 누락 시 예외 처리용
