### PR TITLE
[3-4] 약관 동의 여부

### DIFF
--- a/src/main/java/com/prography/zone_2_be/domain/term/agreement/controller/TermAgreementController.java
+++ b/src/main/java/com/prography/zone_2_be/domain/term/agreement/controller/TermAgreementController.java
@@ -1,11 +1,16 @@
 package com.prography.zone_2_be.domain.term.agreement.controller;
 
+import java.util.List;
+
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+import com.prography.zone_2_be.domain.term.agreement.dto.TermAgreementFindResponse;
 import com.prography.zone_2_be.domain.term.agreement.dto.TermAgreementSaveAllRequest;
 import com.prography.zone_2_be.domain.term.agreement.service.TermAgreementService;
 import com.prography.zone_2_be.global.response.ApiResponse;
@@ -27,5 +32,14 @@ public class TermAgreementController {
 		String uuid = JwtUtil.getUuid();
 		termAgreementService.saveAllTermAgreement(uuid, request.getTermAgreementSaveRequests());
 		return ApiResponse.success();
+	}
+
+	@GetMapping("/status")
+	public ResponseEntity<ApiResponse<List<TermAgreementFindResponse>>> getTermAgreementStatus(
+		@RequestParam List<Long> termIds
+	) {
+		String uuid = JwtUtil.getUuid();
+		List<TermAgreementFindResponse> response = termAgreementService.getTermAgreementStatus(uuid, termIds);
+		return ApiResponse.success(response);
 	}
 }

--- a/src/main/java/com/prography/zone_2_be/domain/term/agreement/dto/TermAgreementFindResponse.java
+++ b/src/main/java/com/prography/zone_2_be/domain/term/agreement/dto/TermAgreementFindResponse.java
@@ -1,0 +1,24 @@
+package com.prography.zone_2_be.domain.term.agreement.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class TermAgreementFindResponse {
+
+	private Long termId;
+	private boolean agreed;
+
+	@Builder
+	private TermAgreementFindResponse(Long termId, boolean agreed) {
+		this.termId = termId;
+		this.agreed = agreed;
+	}
+
+	public static TermAgreementFindResponse of(Long termId, boolean agreed) {
+		return TermAgreementFindResponse.builder()
+			.termId(termId)
+			.agreed(agreed)
+			.build();
+	}
+}

--- a/src/main/java/com/prography/zone_2_be/domain/term/agreement/service/TermAgreementService.java
+++ b/src/main/java/com/prography/zone_2_be/domain/term/agreement/service/TermAgreementService.java
@@ -5,6 +5,7 @@ import java.util.List;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.prography.zone_2_be.domain.term.agreement.dto.TermAgreementFindResponse;
 import com.prography.zone_2_be.domain.term.agreement.dto.TermAgreementSaveRequest;
 import com.prography.zone_2_be.domain.term.agreement.entity.TermAgreement;
 import com.prography.zone_2_be.domain.term.agreement.repository.TermAgreementRepository;
@@ -36,6 +37,22 @@ public class TermAgreementService {
 		List<TermAgreement> newAgreements = createNewAgreements(user, terms);
 
 		termAgreementRepository.saveAll(newAgreements);
+	}
+
+	public List<TermAgreementFindResponse> getTermAgreementStatus(String uuid, List<Long> termIds) {
+		User user = userRepository.findByUuid(uuid).orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+
+		List<Term> terms = findTermsByIds(termIds);
+
+		List<TermAgreement> agreements = termAgreementRepository.findByUserAndTermIn(user, terms);
+
+		return termIds.stream()
+			.map(id -> TermAgreementFindResponse.of(
+				id,
+				agreements.stream()
+					.anyMatch(agreement -> agreement.getTerm().getId().equals(id))
+			))
+			.toList();
 	}
 
 	private void validateAllAgreed(List<TermAgreementSaveRequest> requests) {


### PR DESCRIPTION
## 📝 작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요.

### **TermAgreementController**

* `GET /api/v1/term/agreement/status` 엔드포인트 추가
  → 특정 약관 ID 리스트에 대해 해당 사용자의 동의 여부를 조회하는 API

### **DTO 추가**

* **`TermAgreementFindResponse`**

  * 약관 ID(`termId`)와 동의 여부(`agreed`)를 반환하는 응답 DTO
  * `of(Long termId, boolean agreed)` 팩토리 메서드 제공

### **TermAgreementService**

* **`getTermAgreementStatus(String uuid, List<Long> termIds)`** 메서드 추가

  1. UUID 기반 사용자 조회 (예외: `USER_NOT_FOUND`)
  2. 요청받은 `termIds`로 약관 엔티티 조회 (예외: `TERM_NOT_FOUND`)
  3. 기존 동의 내역 조회 (`findByUserAndTermIn`)
  4. 각 `termId`별 동의 여부 매핑 후 `List<TermAgreementFindResponse>` 반환

