### PR TITLE
[3-4] 약관 동의 여부 로직 리팩토링

### DIFF
--- a/src/main/java/com/prography/zone_2_be/domain/term/agreement/controller/TermAgreementController.java
+++ b/src/main/java/com/prography/zone_2_be/domain/term/agreement/controller/TermAgreementController.java
@@ -14,7 +14,6 @@ import com.prography.zone_2_be.domain.term.agreement.dto.TermAgreementFindRespon
 import com.prography.zone_2_be.domain.term.agreement.dto.TermAgreementSaveAllRequest;
 import com.prography.zone_2_be.domain.term.agreement.service.TermAgreementService;
 import com.prography.zone_2_be.global.response.ApiResponse;
-import com.prography.zone_2_be.global.utils.JwtUtil;
 
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -29,7 +28,7 @@ public class TermAgreementController {
 	@PostMapping("/agree-all")
 	public ResponseEntity<ApiResponse<Void>> saveAllTermAgreement(
 		@RequestBody @Valid TermAgreementSaveAllRequest request) {
-		termAgreementService.saveAllTermAgreement(JwtUtil.getUser(), request.getTermAgreementSaveRequests());
+		termAgreementService.saveAllTermAgreement(request.getTermAgreementSaveRequests());
 		return ApiResponse.success();
 	}
 
@@ -37,8 +36,7 @@ public class TermAgreementController {
 	public ResponseEntity<ApiResponse<List<TermAgreementFindResponse>>> getTermAgreementStatus(
 		@RequestParam List<Long> termIds
 	) {
-		String uuid = JwtUtil.getUuid();
-		List<TermAgreementFindResponse> response = termAgreementService.getTermAgreementStatus(uuid, termIds);
+		List<TermAgreementFindResponse> response = termAgreementService.getTermAgreementStatus(termIds);
 		return ApiResponse.success(response);
 	}
 }

--- a/src/main/java/com/prography/zone_2_be/domain/term/agreement/service/TermAgreementService.java
+++ b/src/main/java/com/prography/zone_2_be/domain/term/agreement/service/TermAgreementService.java
@@ -15,6 +15,7 @@ import com.prography.zone_2_be.domain.user.entity.User;
 import com.prography.zone_2_be.domain.user.repository.UserRepository;
 import com.prography.zone_2_be.global.error.ErrorCode;
 import com.prography.zone_2_be.global.exception.CustomException;
+import com.prography.zone_2_be.global.utils.JwtUtil;
 
 import lombok.RequiredArgsConstructor;
 
@@ -27,7 +28,9 @@ public class TermAgreementService {
 	private final UserRepository userRepository;
 
 	@Transactional
-	public void saveAllTermAgreement(User user, List<TermAgreementSaveRequest> requests) {
+	public void saveAllTermAgreement(List<TermAgreementSaveRequest> requests) {
+		User user = JwtUtil.getUser();
+
 		validateAllAgreed(requests);
 
 		List<Term> terms = findTermsByIds(extractTermIds(requests));
@@ -37,8 +40,8 @@ public class TermAgreementService {
 		termAgreementRepository.saveAll(newAgreements);
 	}
 
-	public List<TermAgreementFindResponse> getTermAgreementStatus(String uuid, List<Long> termIds) {
-		User user = userRepository.findByUuid(uuid).orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+	public List<TermAgreementFindResponse> getTermAgreementStatus(List<Long> termIds) {
+		User user = JwtUtil.getUser();
 
 		List<Term> terms = findTermsByIds(termIds);
 


### PR DESCRIPTION
## 📝 작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요.

### **`TermAgreementService` 리팩토링**

* **`saveAllTermAgreement` 메서드**
    * `User` 엔티티를 파라미터로 받지 않고, **메서드 내부에서 `JwtUtil.getUser()`를 통해 `User` 엔티티를 직접 가져오도록 변경**했습니다.
* **`getTermAgreementStatus` 메서드**
    * `uuid` 파라미터를 제거하고, **메서드 내부에서 `JwtUtil.getUser()`를 통해 `User` 엔티티를 직접 가져오도록 변경**했습니다.
