### PR TITLE
[2-7] OAuth2 액세스 토큰으로 식별자 추출

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -30,6 +30,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation("org.springframework.boot:spring-boot-starter-security")
     implementation("io.jsonwebtoken:jjwt-api:0.12.6")
+    implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
 
     runtimeOnly("io.jsonwebtoken:jjwt-impl:0.12.6")
     runtimeOnly("io.jsonwebtoken:jjwt-jackson:0.12.6")

--- a/src/main/java/com/prography/zone_2_be/domain/auth/dto/UserAuthRequest.java
+++ b/src/main/java/com/prography/zone_2_be/domain/auth/dto/UserAuthRequest.java
@@ -1,9 +1,13 @@
 package com.prography.zone_2_be.domain.auth.dto;
 
 import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
 
+@Getter
 public class UserAuthRequest {
-    @NotNull(message = "OAuth2 키는 필수 입력값입니다.")
-    public String oauth2Key;
+	@NotNull(message = "OAuth2 키는 필수 입력값입니다.")
+	public String oauth2Key;
+	@NotNull(message = "registrationId 필수 입력값입니다.")
+	public String registrationId;
 }
 

--- a/src/main/java/com/prography/zone_2_be/domain/auth/service/AuthService.java
+++ b/src/main/java/com/prography/zone_2_be/domain/auth/service/AuthService.java
@@ -1,7 +1,15 @@
 package com.prography.zone_2_be.domain.auth.service;
 
+import java.time.Instant;
 import java.util.Optional;
 
+import org.springframework.security.oauth2.client.registration.ClientRegistration;
+import org.springframework.security.oauth2.client.registration.ClientRegistrationRepository;
+import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserService;
+import org.springframework.security.oauth2.core.OAuth2AccessToken;
+import org.springframework.security.oauth2.core.user.OAuth2User;
 import org.springframework.stereotype.Service;
 
 import com.prography.zone_2_be.domain.auth.dto.TokenRefreshRequest;
@@ -24,6 +32,9 @@ public class AuthService {
 	private final RefreshTokenHolder refreshTokenHolder;
 	private final JwtUtil jwtUtil;
 
+	private final ClientRegistrationRepository clientRegistrationRepository;
+	private final OAuth2UserService<OAuth2UserRequest, OAuth2User> delegate = new DefaultOAuth2UserService();
+
 	private String createAccessToken(User user) {
 		return jwtUtil.generateAccessToken(user.getOauth2Key(), user.getUuid());
 	}
@@ -32,16 +43,17 @@ public class AuthService {
 		return jwtUtil.generateRefreshToken(user.getUuid());
 	}
 
-	public User createUser(UserAuthRequest request) {
-		User newUser = User.forRegister(request.oauth2Key);
+	public User createUser(String oauth2Key) {
+		User newUser = User.forRegister(oauth2Key);
 		return userRepository.save(newUser);
 	}
 
 	public UserAuthResponse authorize(UserAuthRequest request) {
-		Optional<User> optionalUser = userRepository.findByOauth2Key(request.oauth2Key);
+		String oauth2Key = getOauth2Key(request.getRegistrationId(), request.getOauth2Key());
+		Optional<User> optionalUser = userRepository.findByOauth2Key(oauth2Key);
 		boolean isNew = optionalUser.isEmpty(); // Optional이 비어있으면 새로운 사용자
 
-		User user = optionalUser.orElseGet(() -> createUser(request));
+		User user = optionalUser.orElseGet(() -> createUser(oauth2Key));
 
 		String accessToken = this.createAccessToken(user);
 		String refreshToken = this.createRefreshToken(user);
@@ -82,6 +94,27 @@ public class AuthService {
 			throw new JwtException("Refresh token does not match: " + refreshToken);
 		}
 
+	}
+
+	public String getOauth2Key(String registrationId, String accessToken) {
+
+		ClientRegistration registration =
+			clientRegistrationRepository.findByRegistrationId(registrationId);
+		if (registration == null) {
+			throw new IllegalArgumentException("Unknown OAuth provider: " + registrationId);
+		}
+
+		OAuth2AccessToken token = new OAuth2AccessToken(
+			OAuth2AccessToken.TokenType.BEARER,
+			accessToken,
+			Instant.now(),
+			Instant.now().plusSeconds(60)  // 임시로 60초 만료
+		);
+
+		OAuth2UserRequest userRequest = new OAuth2UserRequest(registration, token);
+
+		OAuth2User oauth2User = delegate.loadUser(userRequest);
+		return oauth2User.getName();
 	}
 
 }


### PR DESCRIPTION
## 📝 작업 내용

> 이번 PR에서는 OAuth2 기반 인증 흐름을 강화하기 위한 작업을 진행했습니다.

* `spring-boot-starter-oauth2-client` 의존성 추가
* `UserAuthRequest` DTO에 `registrationId` 필수 필드 추가
* `AuthService`에 `getOauth2Key()` 메서드 구현:

  * `registrationId`와 클라이언트가 발급한 OAuth 액세스 토큰으로
  * 외부 OAuth 서버의 UserInfo 엔드포인트를 호출하여
