### PR TITLE
[3-1] 약관 조회 구현

### DIFF
--- a/src/main/java/com/prography/zone_2_be/domain/term/agreement/controller/TermAgreementController.java
+++ b/src/main/java/com/prography/zone_2_be/domain/term/agreement/controller/TermAgreementController.java
@@ -5,18 +5,14 @@ import java.util.List;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.prography.zone_2_be.domain.term.agreement.dto.TermAgreementFindResponse;
-import com.prography.zone_2_be.domain.term.agreement.dto.TermAgreementSaveAllRequest;
 import com.prography.zone_2_be.domain.term.agreement.service.TermAgreementService;
 import com.prography.zone_2_be.global.response.ApiResponse;
 
-import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Positive;
@@ -30,13 +26,18 @@ public class TermAgreementController {
 
 	private final TermAgreementService termAgreementService;
 
+	/**
+	 * TODO: 약관 동의 정책에 따라 주석
+	 * 추 후 사용 가능하면 살리기
+	 * @param termIds
+	 * @return
+	 */
 	// @PostMapping("/agree-all")
 	// public ResponseEntity<ApiResponse<Void>> saveAllTermAgreement(
 	// 	@RequestBody @Valid TermAgreementSaveAllRequest request) {
 	// 	termAgreementService.saveAllTermAgreement(request.getTermAgreementSaveRequests());
 	// 	return ApiResponse.success();
 	// }
-
 	@GetMapping("/status")
 	public ResponseEntity<ApiResponse<List<TermAgreementFindResponse>>> getTermAgreementStatus(
 		@RequestParam("termIds") @NotEmpty(message = "termIds는 최소 하나 이상 전달되어야 합니다.")

--- a/src/main/java/com/prography/zone_2_be/domain/term/controller/TermController.java
+++ b/src/main/java/com/prography/zone_2_be/domain/term/controller/TermController.java
@@ -13,6 +13,7 @@ import org.springframework.web.bind.annotation.RestController;
 import com.prography.zone_2_be.domain.term.dto.TermFindAllResponse;
 import com.prography.zone_2_be.domain.term.dto.TermFindAllVersionResponse;
 import com.prography.zone_2_be.domain.term.dto.TermFindResponse;
+import com.prography.zone_2_be.domain.term.entity.TermGroup;
 import com.prography.zone_2_be.domain.term.entity.TermType;
 import com.prography.zone_2_be.domain.term.service.TermService;
 import com.prography.zone_2_be.global.response.ApiResponse;
@@ -48,6 +49,14 @@ public class TermController {
 		@PathVariable("termId") @Positive(message = "termId는 1 이상의 값이어야 합니다.") Long termId
 	) {
 		TermFindResponse response = termService.findTerm(termId);
+		return ApiResponse.success(response);
+	}
+
+	@GetMapping("/type/{termGroup}")
+	public ResponseEntity<ApiResponse<List<TermFindAllResponse>>> findTermByType(
+		@PathVariable("termGroup") TermGroup termGroup) {
+
+		List<TermFindAllResponse> response = termService.findTermByType(termGroup);
 		return ApiResponse.success(response);
 	}
 }

--- a/src/main/java/com/prography/zone_2_be/domain/term/entity/TermGroup.java
+++ b/src/main/java/com/prography/zone_2_be/domain/term/entity/TermGroup.java
@@ -1,0 +1,16 @@
+package com.prography.zone_2_be.domain.term.entity;
+
+import java.util.Arrays;
+import java.util.List;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum TermGroup {
+	SIGN_UP(Arrays.asList(TermType.SERVICE_POLICY, TermType.PERSONAL_INFORMATION_AGREE)),
+	MY_PAGE(Arrays.asList(TermType.SERVICE_POLICY, TermType.PRIVACY_POLICY));
+
+	private final List<TermType> terms;
+}

--- a/src/main/java/com/prography/zone_2_be/domain/term/entity/TermType.java
+++ b/src/main/java/com/prography/zone_2_be/domain/term/entity/TermType.java
@@ -2,6 +2,8 @@ package com.prography.zone_2_be.domain.term.entity;
 
 public enum TermType {
 
-	SERVICE_POLICY,
-	PRIVACY_POLICY
+	SERVICE_POLICY,              // 서비스 이용약관
+	PRIVACY_POLICY,              // 개인정보처리방침
+	PERSONAL_INFORMATION_AGREE   // 개인정보 보호 동의
 }
+

--- a/src/main/java/com/prography/zone_2_be/domain/term/repository/TermRepository.java
+++ b/src/main/java/com/prography/zone_2_be/domain/term/repository/TermRepository.java
@@ -4,6 +4,7 @@ import java.util.List;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import com.prography.zone_2_be.domain.term.entity.Term;
@@ -32,4 +33,17 @@ public interface TermRepository extends JpaRepository<Term, Long> {
 	List<Term> findLatestTermsGroupedByType();
 
 	List<Term> findAllByTermTypeOrderByCreatedAtDesc(TermType type);
+
+	@Query("""
+		    SELECT t
+		    FROM Term t
+		    WHERE t.termType IN :types
+		      AND t.createdAt = (
+		          SELECT MAX(t2.createdAt)
+		          FROM Term t2
+		          WHERE t2.termType = t.termType
+		      )
+		""")
+	List<Term> findLatestTermsByTypes(@Param("types") List<TermType> types);
+
 }

--- a/src/main/java/com/prography/zone_2_be/domain/term/repository/TermRepository.java
+++ b/src/main/java/com/prography/zone_2_be/domain/term/repository/TermRepository.java
@@ -35,14 +35,14 @@ public interface TermRepository extends JpaRepository<Term, Long> {
 	List<Term> findAllByTermTypeOrderByCreatedAtDesc(TermType type);
 
 	@Query("""
-		    SELECT t
-		    FROM Term t
-		    WHERE t.termType IN :types
-		      AND t.createdAt = (
-		          SELECT MAX(t2.createdAt)
-		          FROM Term t2
-		          WHERE t2.termType = t.termType
-		      )
+		SELECT t
+		FROM Term t
+		WHERE t.termType IN :types
+		  AND t.createdAt = (
+			  SELECT MAX(t2.createdAt)
+			  FROM Term t2
+			  WHERE t2.termType = t.termType
+		  )
 		""")
 	List<Term> findLatestTermsByTypes(@Param("types") List<TermType> types);
 

--- a/src/main/java/com/prography/zone_2_be/domain/term/service/TermService.java
+++ b/src/main/java/com/prography/zone_2_be/domain/term/service/TermService.java
@@ -8,6 +8,7 @@ import com.prography.zone_2_be.domain.term.dto.TermFindAllResponse;
 import com.prography.zone_2_be.domain.term.dto.TermFindAllVersionResponse;
 import com.prography.zone_2_be.domain.term.dto.TermFindResponse;
 import com.prography.zone_2_be.domain.term.entity.Term;
+import com.prography.zone_2_be.domain.term.entity.TermGroup;
 import com.prography.zone_2_be.domain.term.entity.TermType;
 import com.prography.zone_2_be.domain.term.repository.TermRepository;
 
@@ -36,5 +37,13 @@ public class TermService {
 	public TermFindResponse findTerm(Long termId) {
 		Term term = termRepository.findByIdOrThrow(termId);
 		return TermFindResponse.from(term);
+	}
+
+	public List<TermFindAllResponse> findTermByType(TermGroup termGroup) {
+		List<TermType> types = termGroup.getTerms();
+
+		return termRepository.findLatestTermsByTypes(types).stream()
+			.map(TermFindAllResponse::from)
+			.toList();
 	}
 }

--- a/src/main/java/com/prography/zone_2_be/global/config/SecurityConfiguration.java
+++ b/src/main/java/com/prography/zone_2_be/global/config/SecurityConfiguration.java
@@ -1,9 +1,5 @@
 package com.prography.zone_2_be.global.config;
 
-import com.prography.zone_2_be.global.exception.AccessDeniedHandlerImpl;
-import com.prography.zone_2_be.global.exception.SecurityAuthenticationEntryPoint;
-import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.boot.web.servlet.FilterRegistrationBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -14,82 +10,87 @@ import org.springframework.security.config.annotation.web.configurers.AbstractHt
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.access.ExceptionTranslationFilter;
-import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+import com.prography.zone_2_be.global.exception.AccessDeniedHandlerImpl;
+import com.prography.zone_2_be.global.exception.SecurityAuthenticationEntryPoint;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
 @Configuration
 @EnableWebSecurity
 @RequiredArgsConstructor
 @Slf4j
 public class SecurityConfiguration {
-    private final JwtAuthFilter jwtAuthFilter;
-    private final SecurityAuthenticationEntryPoint authenticationEntryPoint;
-    private final AccessDeniedHandlerImpl accessDeniedHandler;
+	private final JwtAuthFilter jwtAuthFilter;
+	private final SecurityAuthenticationEntryPoint authenticationEntryPoint;
+	private final AccessDeniedHandlerImpl accessDeniedHandler;
 
-    /**
-     * 공개 API를 위한 SecurityFilterChain (JWT 필터 비활성화)
-     * @Order(1)을 통해 다른 체인보다 우선 순위를 높게 설정합니다.
-     */
-    @Bean
-    @Order(1)
-    public SecurityFilterChain publicFilterChain(HttpSecurity http) throws Exception {
-        http
-                .securityMatcher("/api/v1/health", "/api/v1/auth/register", "/api/v1/auth/login", "/api/v1/auth/refresh")
-                .authorizeHttpRequests(req -> req
-                        // 해당 경로의 모든 요청을 허용합니다.
-                        .anyRequest().permitAll()
-                )
-                // 이 체인에서는 세션을 사용하지 않으므로 csrf, cors 비활성화가 안전합니다.
-                .csrf(AbstractHttpConfigurer::disable)
-                .cors(AbstractHttpConfigurer::disable);
+	/**
+	 * 공개 API를 위한 SecurityFilterChain (JWT 필터 비활성화)
+	 * @Order(1)을 통해 다른 체인보다 우선 순위를 높게 설정합니다.
+	 */
+	@Bean
+	@Order(1)
+	public SecurityFilterChain publicFilterChain(HttpSecurity http) throws Exception {
+		http
+			.securityMatcher("/api/v1/health", "/api/v1/auth/register", "/api/v1/auth/login", "/api/v1/auth/refresh",
+				"/api/v1/term/type/SIGN_UP")
+			.authorizeHttpRequests(req -> req
+				// 해당 경로의 모든 요청을 허용합니다.
+				.anyRequest().permitAll()
+			)
+			// 이 체인에서는 세션을 사용하지 않으므로 csrf, cors 비활성화가 안전합니다.
+			.csrf(AbstractHttpConfigurer::disable)
+			.cors(AbstractHttpConfigurer::disable);
 
-        log.info("Public SecurityFilterChain Bean CREATED!");
-        return http.build();
-    }
+		log.info("Public SecurityFilterChain Bean CREATED!");
+		return http.build();
+	}
 
+	/**
+	 * JWT 인증이 필요한 API를 위한 SecurityFilterChain
+	 * @Order(2)로 두 번째 우선순위를 가집니다.
+	 */
+	@Bean
+	@Order(2)
+	public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+		http
+			// 이 체인은 /api/v1/로 시작하는 모든 요청을 처리합니다.
+			// 하지만 위의 publicFilterChain이 우선순위가 높으므로, 해당 경로들은 먼저 처리되어 이 체인에 도달하지 않습니다.
+			.securityMatcher("/api/v1/**")
+			.csrf(AbstractHttpConfigurer::disable)
+			.cors(AbstractHttpConfigurer::disable)
+			.authorizeHttpRequests(req -> req
+				// 이 체인으로 들어온 모든 요청은 인증을 요구합니다.
+				.anyRequest().authenticated()
+			)
+			.addFilterAfter(jwtAuthFilter, ExceptionTranslationFilter.class)
+			// 예외 처리 핸들러를 등록합니다.
+			.exceptionHandling(exception -> exception
+				.authenticationEntryPoint(authenticationEntryPoint) // 인증 실패 핸들러
+				.accessDeniedHandler(accessDeniedHandler)         // 인가 실패 핸들러
+			);
 
-    /**
-     * JWT 인증이 필요한 API를 위한 SecurityFilterChain
-     * @Order(2)로 두 번째 우선순위를 가집니다.
-     */
-    @Bean
-    @Order(2)
-    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
-        http
-                // 이 체인은 /api/v1/로 시작하는 모든 요청을 처리합니다.
-                // 하지만 위의 publicFilterChain이 우선순위가 높으므로, 해당 경로들은 먼저 처리되어 이 체인에 도달하지 않습니다.
-                .securityMatcher("/api/v1/**")
-                .csrf(AbstractHttpConfigurer::disable)
-                .cors(AbstractHttpConfigurer::disable)
-                .authorizeHttpRequests(req -> req
-                        // 이 체인으로 들어온 모든 요청은 인증을 요구합니다.
-                        .anyRequest().authenticated()
-                )
-                .addFilterAfter(jwtAuthFilter, ExceptionTranslationFilter.class)
-                // 예외 처리 핸들러를 등록합니다.
-                .exceptionHandling(exception -> exception
-                        .authenticationEntryPoint(authenticationEntryPoint) // 인증 실패 핸들러
-                        .accessDeniedHandler(accessDeniedHandler)         // 인가 실패 핸들러
-                );
+		log.info("Secured SecurityFilterChain Bean CREATED!");
+		return http.build();
+	}
 
-        log.info("Secured SecurityFilterChain Bean CREATED!");
-        return http.build();
-    }
+	/**
+	 * JwtAuthFilter를 Spring Security의 필터 체인에서만 사용하고,
+	 * 서블릿 컨테이너에 자동으로 등록되지 않도록 설정합니다.
+	 * @param filter 등록을 비활성화할 필터
+	 * @return FilterRegistrationBean
+	 */
+	@Bean
+	public FilterRegistrationBean<JwtAuthFilter> jwtAuthFilterRegistration(JwtAuthFilter filter) {
+		FilterRegistrationBean<JwtAuthFilter> registration = new FilterRegistrationBean<>(filter);
+		registration.setEnabled(false); // 서블릿 컨테이너의 필터 체인에 등록하지 않음
+		return registration;
+	}
 
-    /**
-     * JwtAuthFilter를 Spring Security의 필터 체인에서만 사용하고,
-     * 서블릿 컨테이너에 자동으로 등록되지 않도록 설정합니다.
-     * @param filter 등록을 비활성화할 필터
-     * @return FilterRegistrationBean
-     */
-    @Bean
-    public FilterRegistrationBean<JwtAuthFilter> jwtAuthFilterRegistration(JwtAuthFilter filter) {
-        FilterRegistrationBean<JwtAuthFilter> registration = new FilterRegistrationBean<>(filter);
-        registration.setEnabled(false); // 서블릿 컨테이너의 필터 체인에 등록하지 않음
-        return registration;
-    }
-
-    @Bean
-    public BCryptPasswordEncoder encodePassword() {
-        return new BCryptPasswordEncoder();
-    }
+	@Bean
+	public BCryptPasswordEncoder encodePassword() {
+		return new BCryptPasswordEncoder();
+	}
 }


### PR DESCRIPTION
## 📝 작업 내용
> 이번 PR에서 작업한 내용을 간략히 설명해주세요.
### **TermGroup & Term 조회 API 개선**
* **`TermGroup` Enum** 추가
  * `SIGN_UP`: `SERVICE_POLICY`, `PERSONAL_INFORMATION_AGREE`
  * `MY_PAGE`: `SERVICE_POLICY`, `PRIVACY_POLICY`
* **`GET /api/v1/term/type/{termGroup}`** 엔드포인트 추가
  → 그룹 단위로 약관을 조회할 수 있는 API 제공
  (예: `SIGN_UP` 요청 시 `SERVICE_POLICY`, `PERSONAL_INFORMATION_AGREE`의 최신 버전만 반환)
---
### **TermRepository**
* **`findLatestTermsByTypes(List<TermType> types)`** 메서드 추가
  * 특정 `TermType` 리스트에 대해 각 타입별 최신 약관 1건만 조회
  * 기존 `findLatestTermsGroupedByType()`와 유사하지만, 타입 제한 조건(`IN (:types)`) 적용
---
### **TermService**
* **`findTermByType(TermGroup termGroup)`** 메서드 추가
  1. 요청받은 `TermGroup` → 내부 `List<TermType>` 매핑
  2. `findLatestTermsByTypes` 호출
  3. 각 타입별 최신 약관 리스트 반환
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit
- **New Features**
  - Endpoint to retrieve the latest terms by group (e.g., Sign Up, My Page), returning the most recent version per term type.
  - Introduced term grouping so clients can request all relevant terms for a user flow in one call.
  - Added “Personal Information Agreement” term type.
- **Chores**
  - Internal plumbing and mappings to support grouped latest-term retrieval.
- **Other**
  - Sign-up terms endpoint exposed as a public route for registration flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->