### PR TITLE
Fix : User 신체 정보 optional 값으로 수정

### DIFF
--- a/src/main/java/com/prography/zone_2_be/domain/user/dto/UserUpdateRequest.java
+++ b/src/main/java/com/prography/zone_2_be/domain/user/dto/UserUpdateRequest.java
@@ -11,9 +11,7 @@ public class UserUpdateRequest {
 	@NotNull(message = "생년월일은 필수입니다.") // null이 아니어야 함
 	@Past(message = "생년월일은 미래의 날짜일 수 없습니다.")
 	public LocalDate birth;
-	@NotNull
 	public Integer height;
-	@NotNull
 	public Integer weight;
 	@NotNull
 	public Gender gender;

--- a/src/main/java/com/prography/zone_2_be/domain/user/entity/User.java
+++ b/src/main/java/com/prography/zone_2_be/domain/user/entity/User.java
@@ -131,8 +131,14 @@ public class User extends BaseEntity implements UserDetails {
 	}
 
 	public void updateUserInfo(UserUpdateRequest dto) {
-		this.weight = dto.weight;
-		this.height = dto.height;
+		if (dto.weight != null) {
+			this.weight = dto.weight;
+		}
+
+		if (dto.height != null) {
+			this.height = dto.height;
+		}
+
 		this.birth = dto.birth;
 		this.gender = dto.gender;
 	}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Profile updates now allow height and weight to be optional, letting you update other details without providing these fields.
- Bug Fixes
  - Existing height and weight values are preserved when those fields are omitted during profile updates, preventing unintended overwrites.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->