### PR TITLE
Fix : WorkoutGetHistoryResponse 생성자 파라미터 순서 오류 수정

### DIFF
--- a/src/main/java/com/prography/zone_2_be/domain/workout/service/WorkoutService.java
+++ b/src/main/java/com/prography/zone_2_be/domain/workout/service/WorkoutService.java
@@ -43,11 +43,11 @@ public class WorkoutService {
 	}
 
 	private Integer getZone2FatUsage(Integer kcalUsage) {
-		return (int) (kcalUsage * 0.65) / 9;
+		return (int)(kcalUsage * 0.65) / 9;
 	}
 
 	private Integer getZone4FatUsage(Integer kcalUsage) {
-		return (int) (kcalUsage * 1.5 * 0.15) / 9;
+		return (int)(kcalUsage * 1.5 * 0.15) / 9;
 	}
 
 	public WorkoutGetFatUsageResponse getFatUsage(Integer kcalUsage) {
@@ -94,8 +94,8 @@ public class WorkoutService {
 		// 3. 두 결과를 최종 WorkoutGetHistoryResponse DTO에 담아 반환
 		return new WorkoutGetHistoryResponse(
 			total.getExecTimeSum(),
-			total.getFatUsageSum(),
 			total.getKcalUsageSum(),
+			total.getFatUsageSum(),
 			histories
 		);
 
@@ -123,7 +123,8 @@ public class WorkoutService {
 		Workout workout = workoutRepository.findByUuid(uuid)
 			.orElseThrow(WorkoutNotFoundException::new);
 
-		return WorkoutGetResultResponse.from(workout, getRelativeFatUsage(workout.getKcalUsage()), getZone2FatUsage(workout.getKcalUsage()), getZone4FatUsage(workout.getKcalUsage()),
+		return WorkoutGetResultResponse.from(workout, getRelativeFatUsage(workout.getKcalUsage()),
+			getZone2FatUsage(workout.getKcalUsage()), getZone4FatUsage(workout.getKcalUsage()),
 			FoodFigure.matchFatUsageAndFoodFigure(workout.getFatUsage()));
 	}
 

--- a/src/test/java/com/prography/zone_2_be/domain/customerinquiry/repository/CustomerInquiryRepositoryTest.java
+++ b/src/test/java/com/prography/zone_2_be/domain/customerinquiry/repository/CustomerInquiryRepositoryTest.java
@@ -2,6 +2,7 @@ package com.prography.zone_2_be.domain.customerinquiry.repository;
 
 import static org.assertj.core.api.Assertions.*;
 
+import java.time.Instant;
 import java.util.List;
 
 import org.junit.jupiter.api.DisplayName;
@@ -33,11 +34,11 @@ class CustomerInquiryRepositoryTest {
 			.toList();
 
 		for (int i = 0; i < pinned.size() - 1; i++) {
-			Long current = pinned.get(i).getCreatedAt();
-			Long next = pinned.get(i + 1).getCreatedAt();
+			Instant current = pinned.get(i).getCreatedAt();
+			Instant next = pinned.get(i + 1).getCreatedAt();
 			assertThat(current)
 				.as("Pinned 그룹 내에서 createdAt 내림차순이 유지되어야 한다")
-				.isGreaterThanOrEqualTo(next);
+				.isAfterOrEqualTo(next);
 		}
 	}
 
@@ -53,11 +54,11 @@ class CustomerInquiryRepositoryTest {
 			.toList();
 
 		for (int i = 0; i < normal.size() - 1; i++) {
-			Long current = normal.get(i).getCreatedAt();
-			Long next = normal.get(i + 1).getCreatedAt();
+			Instant current = normal.get(i).getCreatedAt();
+			Instant next = normal.get(i + 1).getCreatedAt();
 			assertThat(current)
 				.as("Normal 그룹 내에서 createdAt 내림차순이 유지되어야 한다")
-				.isGreaterThanOrEqualTo(next);
+				.isAfterOrEqualTo(next);
 		}
 	}
 

--- a/src/test/java/com/prography/zone_2_be/domain/workout/WorkoutServiceTest.java
+++ b/src/test/java/com/prography/zone_2_be/domain/workout/WorkoutServiceTest.java
@@ -1,27 +1,33 @@
 package com.prography.zone_2_be.domain.workout;
 
-import java.time.Instant;
+import static org.assertj.core.api.Assertions.*;
+
 import java.time.LocalDateTime;
+import java.time.ZoneId;
 import java.time.ZoneOffset;
 import java.util.Arrays;
 import java.util.List;
 import java.util.UUID;
 import java.util.concurrent.ThreadLocalRandom;
 
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.context.ActiveProfiles;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
 
 import com.prography.zone_2_be.domain.user.entity.User;
 import com.prography.zone_2_be.domain.user.repository.UserRepository;
+import com.prography.zone_2_be.domain.workout.dto.WorkoutGetHistoryResponse;
 import com.prography.zone_2_be.domain.workout.entity.Activity;
 import com.prography.zone_2_be.domain.workout.entity.Workout;
 import com.prography.zone_2_be.domain.workout.repository.WorkoutRepository;
+import com.prography.zone_2_be.domain.workout.service.WorkoutService;
 import com.prography.zone_2_be.global.utils.JwtUtil;
 
 @SpringBootTest
-@ActiveProfiles("test")
+// @ActiveProfiles("main")
 public class WorkoutServiceTest {
 
 	@Autowired
@@ -29,6 +35,9 @@ public class WorkoutServiceTest {
 
 	@Autowired
 	private WorkoutRepository workoutRepository;
+
+	@Autowired
+	private WorkoutService workoutService;
 
 	@Autowired
 	private JwtUtil jwtUtil;
@@ -48,8 +57,40 @@ public class WorkoutServiceTest {
 	public void createDummyDataWithJWT() {
 		String token = "eyJhbGciOiJIUzM4NCJ9.eyJqdGkiOiIxYTQ5OThhOS03YjczLTRhOTItYjkyOC1kZmZiMTMyYWQ5MjUiLCJzdWIiOiJrZXkiLCJpYXQiOjE3NTI5OTUyNzQsImV4cCI6MTc1Mjk5ODg3NH0.7-696ZgV6x_Dr3MVlmDL1398x11XaxHimf3RiPQNp5nYKuHXvBHKQNKbU3aSrzEn";
 
-		createDummyData(jwtUtil.getOAuth2Key(token));
+		// createDummyData(jwtUtil.getOAuth2Key(token));
 
+	}
+
+	@Test
+	@DisplayName("운동 기록 조회 - 정상 케이스")
+	public void getWorkoutHistory_Success() {
+		// Given
+		// 테스트용 사용자 생성 및 저장
+		User testUser = userRepository.findById(1L).orElseThrow();
+
+		// SecurityContext에 인증 정보 설정
+		UsernamePasswordAuthenticationToken authentication =
+			new UsernamePasswordAuthenticationToken(testUser, null, testUser.getAuthorities());
+		SecurityContextHolder.getContext().setAuthentication(authentication);
+
+		LocalDateTime startDate = LocalDateTime.of(2025, 10, 1, 0, 0, 0);
+		long startTime = startDate.atZone(ZoneId.systemDefault()).toEpochSecond();
+		LocalDateTime endDate = LocalDateTime.of(2025, 10, 21, 0, 0, 0);
+		long endTime = endDate.atZone(ZoneId.systemDefault()).toEpochSecond();
+
+		// When
+		WorkoutGetHistoryResponse response = workoutService.getWorkoutHistory(startTime, endTime, 0, 10);
+
+		// Then
+		assertThat(response).isNotNull();
+		assertThat(response.getHistories()).isNotEmpty();
+		System.out.println("Total Exec Time: " + response.getTotalExecTime());
+		System.out.println("Total Kcal Usage: " + response.getTotalKcalUsage());
+		System.out.println("Total Fat Usage: " + response.getTotalZone2FatUsage());
+		System.out.println("Histories Size: " + response.getHistories().size());
+
+		// SecurityContext 정리
+		SecurityContextHolder.clearContext();
 	}
 
 	public void createDummyData(String oauth2Key) {
@@ -93,7 +134,7 @@ public class WorkoutServiceTest {
 			// 2. 해당 범위 내에서 랜덤 long 값을 생성합니다.
 			long randomEpochSecond = ThreadLocalRandom.current().nextLong(startEpochSecond, endEpochSecond);
 
-			workout.setCreatedAt(Instant.ofEpochSecond(randomEpochSecond));
+			// workout.setCreatedAt(Instant.ofEpochSecond(randomEpochSecond));
 			// 7. 생성된 엔티티를 저장합니다.
 			workoutRepository.save(workout);
 		}


### PR DESCRIPTION
## 📝 작업 내용
> 이번 PR에서 작업한 내용을 간략히 설명해주세요.

### **운동 이력 조회 API 데이터 오류 수정**
* **`WorkoutGetHistoryResponse` 생성자 파라미터 순서 수정**
  * 칼로리 사용량(`kcalUsageSum`)과 지방 사용량(`fatUsageSum`) 파라미터가 잘못된 순서로 전달되던 문제 해결
  * UI에서 칼로리와 지방 사용량이 뒤바뀌어 표시되던 버그 수정

---

### **변경 사항**
* **WorkoutService** (또는 해당 서비스/컨트롤러 클래스명)
  * `WorkoutGetHistoryResponse` 생성자 호출 시 파라미터 순서를 DTO 정의와 일치하도록 수정
  * 변경 전: `new WorkoutGetHistoryResponse(execTime, fatUsage, kcalUsage, histories)`
  * 변경 후: `new WorkoutGetHistoryResponse(execTime, kcalUsage, fatUsage, histories)`
