### PR TITLE
Feat : 운동기록 저장

### DIFF
--- a/src/main/java/com/prography/zone_2_be/domain/workout/controller/WorkoutController.java
+++ b/src/main/java/com/prography/zone_2_be/domain/workout/controller/WorkoutController.java
@@ -14,6 +14,7 @@ import com.prography.zone_2_be.domain.workout.dto.WorkoutGetHistoryResponse;
 import com.prography.zone_2_be.domain.workout.dto.WorkoutGetResultResponse;
 import com.prography.zone_2_be.domain.workout.dto.WorkoutGetZone2Response;
 import com.prography.zone_2_be.domain.workout.dto.WorkoutSaveRequest;
+import com.prography.zone_2_be.domain.workout.dto.WorkoutSaveResponse;
 import com.prography.zone_2_be.domain.workout.service.WorkoutService;
 import com.prography.zone_2_be.global.response.ApiResponse;
 
@@ -73,8 +74,9 @@ public class WorkoutController {
 	}
 
 	@PostMapping
-	public ResponseEntity<ApiResponse<Void>> saveWorkout(@RequestBody @Valid WorkoutSaveRequest workoutSaveRequest) {
-		workoutService.saveWorkout(workoutSaveRequest);
-		return ApiResponse.success();
+	public ResponseEntity<ApiResponse<WorkoutSaveResponse>> saveWorkout(
+		@RequestBody @Valid WorkoutSaveRequest workoutSaveRequest) {
+		WorkoutSaveResponse result = workoutService.saveWorkout(workoutSaveRequest);
+		return ApiResponse.success(result);
 	}
 }

--- a/src/main/java/com/prography/zone_2_be/domain/workout/dto/WorkoutSaveResponse.java
+++ b/src/main/java/com/prography/zone_2_be/domain/workout/dto/WorkoutSaveResponse.java
@@ -1,0 +1,29 @@
+package com.prography.zone_2_be.domain.workout.dto;
+
+import com.prography.zone_2_be.domain.workout.entity.Workout;
+
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class WorkoutSaveResponse {
+
+	private String uuid;
+	private int activity;
+
+	@Builder(access = AccessLevel.PRIVATE)
+	private WorkoutSaveResponse(String uuid, int activity) {
+		this.uuid = uuid;
+		this.activity = activity;
+	}
+
+	public static WorkoutSaveResponse from(Workout workout) {
+		return WorkoutSaveResponse.builder()
+			.uuid(workout.getUuid())
+			.activity(workout.getActivity().getValue())
+			.build();
+	}
+}

--- a/src/main/java/com/prography/zone_2_be/domain/workout/service/WorkoutService.java
+++ b/src/main/java/com/prography/zone_2_be/domain/workout/service/WorkoutService.java
@@ -23,6 +23,7 @@ import com.prography.zone_2_be.domain.workout.dto.WorkoutGetResultResponse;
 import com.prography.zone_2_be.domain.workout.dto.WorkoutGetZone2Response;
 import com.prography.zone_2_be.domain.workout.dto.WorkoutHistoryDto;
 import com.prography.zone_2_be.domain.workout.dto.WorkoutSaveRequest;
+import com.prography.zone_2_be.domain.workout.dto.WorkoutSaveResponse;
 import com.prography.zone_2_be.domain.workout.entity.Workout;
 import com.prography.zone_2_be.domain.workout.exception.WorkoutNotFoundException;
 import com.prography.zone_2_be.domain.workout.repository.WorkoutRepository;
@@ -129,7 +130,7 @@ public class WorkoutService {
 	}
 
 	@Transactional
-	public void saveWorkout(WorkoutSaveRequest workoutSaveRequest) {
+	public WorkoutSaveResponse saveWorkout(WorkoutSaveRequest workoutSaveRequest) {
 		User user = JwtUtil.getUser();
 		String uuid = UUID.randomUUID().toString();
 		int fatUsage = getZone2FatUsage(workoutSaveRequest.getKcalUsage());
@@ -142,5 +143,7 @@ public class WorkoutService {
 			fatUsage, workoutSaveRequest.getZone2Rate(), workoutSaveRequest.getActivity());
 
 		workoutRepository.save(workout);
+
+		return WorkoutSaveResponse.from(workout);
 	}
 }


### PR DESCRIPTION
 📝 작업 내용

  이번 PR에서 작업한 내용을 간략히 설명해주세요.

  운동 기록 저장 API 응답 형식 개선

  - WorkoutSaveResponse DTO 추가
    - 저장된 운동 기록의 UUID와 활동 타입(activity)을 응답으로 반환하도록 개선

  ---
  변경 사항

  - WorkoutSaveResponse (신규 생성)
    - 운동 기록 저장 후 반환할 응답 DTO 생성
    - uuid: 저장된 운동 기록의 고유 식별자
    - activity: 활동 타입 (숫자 값으로 반환)
  - WorkoutService
    - saveWorkout() 메서드 반환 타입 변경
    - 변경 전: void (응답 없음)
    - 변경 후: WorkoutSaveResponse (저장된 데이터 반환)
  - WorkoutController
    - POST /api/v1/workout 엔드포인트 응답 타입 수정
    - 변경 전: ApiResponse<Void> (빈 응답)
    - 변경 후: ApiResponse<WorkoutSaveResponse> (UUID, activity 포함)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  - Save workout endpoint now returns the saved workout's unique identifier and activity type upon successful completion, providing users with immediate feedback and meaningful response data instead of empty confirmation.

* **Refactor**
  - Enhanced the workout save operation throughout the system to include saved workout details in API responses for improved user experience and feedback.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->