### PR TITLE
Feat : WorkoutGetResultResponse에 uuid, activity 필드 추가 및 매핑 로직 반영

### DIFF
--- a/src/main/java/com/prography/zone_2_be/domain/workout/dto/WorkoutGetResultResponse.java
+++ b/src/main/java/com/prography/zone_2_be/domain/workout/dto/WorkoutGetResultResponse.java
@@ -1,35 +1,40 @@
 package com.prography.zone_2_be.domain.workout.dto;
 
-
 import com.prography.zone_2_be.domain.workout.entity.Workout;
+
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
-import lombok.RequiredArgsConstructor;
 
 @Builder
 @AllArgsConstructor
 @Getter
 public class WorkoutGetResultResponse {
-    private Long execTime;
-    private Integer zone2Rate;
-    private Integer kcalUsage;
-    private Integer relativeFatUsage;
-    private Integer zone2FatUsage;
-    private Integer zone4FatUsage;
-    private Integer foodFigure;
-    private Long createdAt;
 
-    public static WorkoutGetResultResponse from(Workout workout, Integer relativeFatUsage, Integer zone2FatUsage, Integer zone4FatUsage, FoodFigure foodFigure) {
-        return WorkoutGetResultResponse.builder()
-                .execTime(workout.getExecTime())
-                .zone2Rate(workout.getZone2Rate())
-                .kcalUsage(workout.getKcalUsage())
-                .relativeFatUsage(relativeFatUsage)
-                .zone2FatUsage(zone2FatUsage)
-                .zone4FatUsage(zone4FatUsage)
-                .foodFigure(foodFigure.getValue())
-                .createdAt(workout.getCreatedAt().getEpochSecond())
-                .build();
-    }
+	private String uuid;
+	private Long execTime;
+	private Integer zone2Rate;
+	private Integer kcalUsage;
+	private Integer relativeFatUsage;
+	private Integer zone2FatUsage;
+	private Integer zone4FatUsage;
+	private Integer foodFigure;
+	private int activity;
+	private Long createdAt;
+
+	public static WorkoutGetResultResponse from(Workout workout, Integer relativeFatUsage, Integer zone2FatUsage,
+		Integer zone4FatUsage, FoodFigure foodFigure) {
+		return WorkoutGetResultResponse.builder()
+			.uuid(workout.getUuid())
+			.activity(workout.getActivity().getValue())
+			.execTime(workout.getExecTime())
+			.zone2Rate(workout.getZone2Rate())
+			.kcalUsage(workout.getKcalUsage())
+			.relativeFatUsage(relativeFatUsage)
+			.zone2FatUsage(zone2FatUsage)
+			.zone4FatUsage(zone4FatUsage)
+			.foodFigure(foodFigure.getValue())
+			.createdAt(workout.getCreatedAt().getEpochSecond())
+			.build();
+	}
 }


### PR DESCRIPTION
  ## 🎯 작업 내용
  - WorkoutGetResultResponse에 uuid, activity 필드 추가
  - Workout 엔티티의 uuid와 activity 값을 응답에 매핑

  ## 📝 상세 설명
  운동 기록 조회 시 클라이언트에서 필요한 정보를 추가로 제공하기 위해:
  - `uuid`: 운동 기록 고유 식별자 추가
  - `activity`: 운동 활동 타입 정보 추가

  ## ✅ 테스트
  - [x] 포스트맨 테스트 확인
  - [x] 새로운 필드가 응답에 포함되는지 확인

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Workout results now include unique identifier and activity type information for enhanced workout tracking and identification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->