### PR TITLE
Feat : 알림 설정 기능 구현

### DIFF
--- a/src/main/java/com/prography/zone_2_be/domain/alarm/controller/AlarmController.java
+++ b/src/main/java/com/prography/zone_2_be/domain/alarm/controller/AlarmController.java
@@ -1,0 +1,19 @@
+package com.prography.zone_2_be.domain.alarm.controller;
+
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.prography.zone_2_be.domain.alarm.service.AlarmService;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/alarm")
+@Slf4j
+public class AlarmController {
+
+	private final AlarmService alarmService;
+
+}

--- a/src/main/java/com/prography/zone_2_be/domain/alarm/controller/AlarmController.java
+++ b/src/main/java/com/prography/zone_2_be/domain/alarm/controller/AlarmController.java
@@ -1,10 +1,20 @@
 package com.prography.zone_2_be.domain.alarm.controller;
 
+import java.util.List;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import com.prography.zone_2_be.domain.alarm.dto.request.AlarmUpdateRequest;
+import com.prography.zone_2_be.domain.alarm.dto.response.AlarmFindResponse;
 import com.prography.zone_2_be.domain.alarm.service.AlarmService;
+import com.prography.zone_2_be.global.response.ApiResponse;
 
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
@@ -16,4 +26,21 @@ public class AlarmController {
 
 	private final AlarmService alarmService;
 
+	/**
+	 * 사용자의 알림 전체 조회
+	 */
+	@GetMapping
+	public ResponseEntity<ApiResponse<List<AlarmFindResponse>>> findAllAlarmByUser() {
+		List<AlarmFindResponse> response = alarmService.findAllAlarmByUser();
+		return ApiResponse.success(response);
+	}
+
+	/**
+	 * 사용자의 알림 설정 수정
+	 */
+	@PostMapping
+	public ResponseEntity<ApiResponse<Void>> updateAlarm(@Valid @RequestBody AlarmUpdateRequest request) {
+		alarmService.updateAlarm(request);
+		return ApiResponse.success();
+	}
 }

--- a/src/main/java/com/prography/zone_2_be/domain/alarm/dto/request/AlarmUpdateRequest.java
+++ b/src/main/java/com/prography/zone_2_be/domain/alarm/dto/request/AlarmUpdateRequest.java
@@ -1,0 +1,19 @@
+package com.prography.zone_2_be.domain.alarm.dto.request;
+
+import com.prography.zone_2_be.domain.alarm.entity.AlarmType;
+
+import jakarta.validation.constraints.NotNull;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class AlarmUpdateRequest {
+
+	@NotNull(message = "alarmType은 필수입니다.")
+	private AlarmType alarmType;
+
+	@NotNull(message = "enabled 값은 필수입니다.")
+	private Boolean enabled;
+}

--- a/src/main/java/com/prography/zone_2_be/domain/alarm/dto/response/AlarmFindResponse.java
+++ b/src/main/java/com/prography/zone_2_be/domain/alarm/dto/response/AlarmFindResponse.java
@@ -1,0 +1,28 @@
+package com.prography.zone_2_be.domain.alarm.dto.response;
+
+import com.prography.zone_2_be.domain.alarm.entity.Alarm;
+import com.prography.zone_2_be.domain.alarm.entity.AlarmType;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class AlarmFindResponse {
+
+	private AlarmType alarmType;
+
+	private boolean enabled;
+
+	@Builder
+	private AlarmFindResponse(AlarmType alarmType, boolean enabled) {
+		this.alarmType = alarmType;
+		this.enabled = enabled;
+	}
+
+	public static AlarmFindResponse from(Alarm alarm) {
+		return AlarmFindResponse.builder()
+			.alarmType(alarm.getAlarmType())
+			.enabled(alarm.isEnabled())
+			.build();
+	}
+}

--- a/src/main/java/com/prography/zone_2_be/domain/alarm/entity/Alarm.java
+++ b/src/main/java/com/prography/zone_2_be/domain/alarm/entity/Alarm.java
@@ -1,0 +1,57 @@
+package com.prography.zone_2_be.domain.alarm.entity;
+
+import com.prography.zone_2_be.domain.user.entity.User;
+import com.prography.zone_2_be.global.entity.UpdatableEntity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(uniqueConstraints = {
+	@UniqueConstraint(columnNames = {"user_id", "alarm_type"})
+})
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Alarm extends UpdatableEntity {
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "user_id", nullable = false)
+	private User user;
+
+	@Enumerated(EnumType.STRING)
+	@Column(name = "alarm_type", nullable = false)
+	private AlarmType alarmType;
+
+	@Column(nullable = false)
+	private boolean enabled;
+
+	@Builder
+	private Alarm(User user, AlarmType alarmType, boolean enabled) {
+		this.user = user;
+		this.alarmType = alarmType;
+		this.enabled = enabled;
+	}
+
+	public static Alarm of(User user, AlarmType alarmType) {
+		return Alarm.builder()
+			.user(user)
+			.alarmType(alarmType)
+			.enabled(alarmType.isEssential())
+			.build();
+	}
+
+	public void updateEnabled(boolean enabled) {
+		this.enabled = enabled;
+	}
+}

--- a/src/main/java/com/prography/zone_2_be/domain/alarm/entity/AlarmType.java
+++ b/src/main/java/com/prography/zone_2_be/domain/alarm/entity/AlarmType.java
@@ -1,0 +1,21 @@
+package com.prography.zone_2_be.domain.alarm.entity;
+
+import java.util.Arrays;
+import java.util.List;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum AlarmType {
+	WORKOUT_REPORT("workout_report", true),        // 필수 알림
+	NEWS_AND_BENEFITS("news_benefits", false);        // 선택적 알림 (마케팅)
+
+	private final String code;
+	private final boolean essential;                // 필수 알림 여부
+
+	public static List<AlarmType> getAllTypes() {
+		return Arrays.asList(values());
+	}
+}

--- a/src/main/java/com/prography/zone_2_be/domain/alarm/repository/AlarmRepository.java
+++ b/src/main/java/com/prography/zone_2_be/domain/alarm/repository/AlarmRepository.java
@@ -1,0 +1,11 @@
+package com.prography.zone_2_be.domain.alarm.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import com.prography.zone_2_be.domain.alarm.entity.Alarm;
+
+@Repository
+public interface AlarmRepository extends JpaRepository<Alarm, Long> {
+
+}

--- a/src/main/java/com/prography/zone_2_be/domain/alarm/repository/AlarmRepository.java
+++ b/src/main/java/com/prography/zone_2_be/domain/alarm/repository/AlarmRepository.java
@@ -1,11 +1,19 @@
 package com.prography.zone_2_be.domain.alarm.repository;
 
+import java.util.List;
+import java.util.Optional;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 import com.prography.zone_2_be.domain.alarm.entity.Alarm;
+import com.prography.zone_2_be.domain.alarm.entity.AlarmType;
+import com.prography.zone_2_be.domain.user.entity.User;
 
 @Repository
 public interface AlarmRepository extends JpaRepository<Alarm, Long> {
 
+	Optional<Alarm> findByUserAndAlarmType(User user, AlarmType alarmType);
+
+	List<Alarm> findAllByUser(User user);
 }

--- a/src/main/java/com/prography/zone_2_be/domain/alarm/service/AlarmService.java
+++ b/src/main/java/com/prography/zone_2_be/domain/alarm/service/AlarmService.java
@@ -5,11 +5,17 @@ import java.util.List;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.prography.zone_2_be.domain.alarm.dto.request.AlarmUpdateRequest;
+import com.prography.zone_2_be.domain.alarm.dto.response.AlarmFindResponse;
 import com.prography.zone_2_be.domain.alarm.entity.Alarm;
 import com.prography.zone_2_be.domain.alarm.entity.AlarmType;
 import com.prography.zone_2_be.domain.alarm.repository.AlarmRepository;
 import com.prography.zone_2_be.domain.user.entity.User;
+import com.prography.zone_2_be.global.error.ErrorCode;
+import com.prography.zone_2_be.global.exception.CustomException;
+import com.prography.zone_2_be.global.utils.JwtUtil;
 
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 
 @Service
@@ -31,4 +37,30 @@ public class AlarmService {
 		alarmRepository.saveAll(alarms);
 	}
 
+	/**
+	 * 사용자의 모든 알림 설정 조회
+	 */
+	@Transactional(readOnly = true)
+	public List<AlarmFindResponse> findAllAlarmByUser() {
+		User user = JwtUtil.getUser();
+
+		return alarmRepository.findAllByUser(user).stream()
+			.map(AlarmFindResponse::from)
+			.toList();
+	}
+
+	/**
+	 * 사용자의 알림 설정 수정
+	 */
+	@Transactional
+	public void updateAlarm(@Valid AlarmUpdateRequest request) {
+
+		User user = JwtUtil.getUser();
+
+		Alarm alarm = alarmRepository
+			.findByUserAndAlarmType(user, request.getAlarmType())
+			.orElseThrow(() -> new CustomException(ErrorCode.ALARM_NOT_FOUND));
+
+		alarm.updateEnabled(request.getEnabled());
+	}
 }

--- a/src/main/java/com/prography/zone_2_be/domain/alarm/service/AlarmService.java
+++ b/src/main/java/com/prography/zone_2_be/domain/alarm/service/AlarmService.java
@@ -1,8 +1,14 @@
 package com.prography.zone_2_be.domain.alarm.service;
 
-import org.springframework.stereotype.Service;
+import java.util.List;
 
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.prography.zone_2_be.domain.alarm.entity.Alarm;
+import com.prography.zone_2_be.domain.alarm.entity.AlarmType;
 import com.prography.zone_2_be.domain.alarm.repository.AlarmRepository;
+import com.prography.zone_2_be.domain.user.entity.User;
 
 import lombok.RequiredArgsConstructor;
 
@@ -11,5 +17,18 @@ import lombok.RequiredArgsConstructor;
 public class AlarmService {
 
 	private final AlarmRepository alarmRepository;
+
+	/**
+	 * 회원가입 시 알림 설정 초기화
+	 */
+	@Transactional
+	public void initializeAlarmByUser(User user) {
+
+		List<Alarm> alarms = AlarmType.getAllTypes().stream()
+			.map(type -> Alarm.of(user, type))
+			.toList();
+
+		alarmRepository.saveAll(alarms);
+	}
 
 }

--- a/src/main/java/com/prography/zone_2_be/domain/alarm/service/AlarmService.java
+++ b/src/main/java/com/prography/zone_2_be/domain/alarm/service/AlarmService.java
@@ -1,0 +1,15 @@
+package com.prography.zone_2_be.domain.alarm.service;
+
+import org.springframework.stereotype.Service;
+
+import com.prography.zone_2_be.domain.alarm.repository.AlarmRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class AlarmService {
+
+	private final AlarmRepository alarmRepository;
+
+}

--- a/src/main/java/com/prography/zone_2_be/domain/auth/service/AuthService.java
+++ b/src/main/java/com/prography/zone_2_be/domain/auth/service/AuthService.java
@@ -16,6 +16,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import com.nimbusds.jwt.JWTClaimsSet;
 import com.nimbusds.jwt.JWTParser;
+import com.prography.zone_2_be.domain.alarm.service.AlarmService;
 import com.prography.zone_2_be.domain.auth.dto.TokenRefreshRequest;
 import com.prography.zone_2_be.domain.auth.dto.TokenRefreshResponse;
 import com.prography.zone_2_be.domain.auth.dto.UserAuthResponse;
@@ -40,6 +41,8 @@ import lombok.extern.slf4j.Slf4j;
 @RequiredArgsConstructor
 @Slf4j
 public class AuthService {
+
+	private final AlarmService alarmService;
 	private final TermAgreementService termAgreementService;
 
 	private final UserRepository userRepository;
@@ -62,6 +65,8 @@ public class AuthService {
 	public UserAuthResponse register(UserRegisterRequest request, String oauthToken) {
 		User user = createUser(request, oauthToken);
 
+		alarmService.initializeAlarmByUser(user);
+
 		String newAccessToken = createAccessToken(user);
 		String newRefreshToken = createRefreshToken(user);
 
@@ -73,13 +78,13 @@ public class AuthService {
 		return UserAuthResponse.of(newAccessToken, newRefreshToken);
 	}
 
-	public UserAuthResponse login(UserLoginRequest request, String oauthToken){
+	public UserAuthResponse login(UserLoginRequest request, String oauthToken) {
 		String oauth2Key = getOauth2Key(request.getRegistrationId(), oauthToken);
 		// String oauth2Key = "not exist key";
 
 		Optional<User> userOpt = userRepository.findByOauth2Key(oauth2Key);
 
-		if (userOpt.isEmpty()){
+		if (userOpt.isEmpty()) {
 			return UserAuthResponse.asNew(null, null);
 		}
 
@@ -101,11 +106,11 @@ public class AuthService {
 		return UserAuthResponse.of(newAccessToken, newRefreshToken);
 	}
 
-	public User createUser(UserRegisterRequest request, String oauthToken){
+	public User createUser(UserRegisterRequest request, String oauthToken) {
 		String oauth2Key = getOauth2Key(request.getRegistrationId(), oauthToken);
 		// String oauth2Key = "newkey4";
 
-		if (userRepository.existsByOauth2Key(oauth2Key)){
+		if (userRepository.existsByOauth2Key(oauth2Key)) {
 			throw new CustomException(ErrorCode.ALREADY_USER_EXISTS);
 		}
 
@@ -123,7 +128,6 @@ public class AuthService {
 		String uuid = jwtUtil.getUuid(refreshToken);
 		User user = userRepository.findByUuid(uuid)
 			.orElseThrow(UserNotFoundException::new);
-
 
 		String newAccessToken = this.createAccessToken(user);
 		String newRefreshToken = this.createRefreshToken(user);

--- a/src/main/java/com/prography/zone_2_be/global/error/ErrorCode.java
+++ b/src/main/java/com/prography/zone_2_be/global/error/ErrorCode.java
@@ -34,6 +34,9 @@ public enum ErrorCode {
 	WORKOUT_NOT_FOUND(HttpStatus.NOT_FOUND, 4401, "해당 UUID의 운동 기록을 찾을 수 없습니다."),
 	WORKOUT_REQUIREMENTS_NOT_MET(HttpStatus.BAD_REQUEST, 4402, "운동 요건을 충족시키지 못했습니다."),
 
+	// Alarm 에러 4500번대
+	ALARM_NOT_FOUND(HttpStatus.NOT_FOUND, 4500, "해당 알림 설정을 찾을 수 없습니다."),
+
 	// Global Server 에러
 	DEFAULT_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, 5000, "서버에서 알 수 없는 오류 발생.");
 

--- a/src/test/java/com/prography/zone_2_be/domain/auth/controller/AuthControllerTest.java
+++ b/src/test/java/com/prography/zone_2_be/domain/auth/controller/AuthControllerTest.java
@@ -1,4 +1,55 @@
 package com.prography.zone_2_be.domain.auth.controller;
 
+import java.util.Optional;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.annotation.Rollback;
+import org.springframework.test.context.ActiveProfiles;
+
+import com.prography.zone_2_be.domain.auth.repository.AccessTokenRepository;
+import com.prography.zone_2_be.domain.auth.repository.RefreshTokenRepository;
+import com.prography.zone_2_be.domain.user.entity.User;
+import com.prography.zone_2_be.domain.user.repository.UserRepository;
+import com.prography.zone_2_be.global.utils.JwtUtil;
+
+import jakarta.transaction.Transactional;
+
+@SpringBootTest
+@ActiveProfiles("test")
 public class AuthControllerTest {
+
+	@Autowired
+	private UserRepository userRepository;
+
+	@Autowired
+	private AccessTokenRepository accessTokenRepository;
+
+	@Autowired
+	private RefreshTokenRepository refreshTokenRepository;
+
+	@Autowired
+	private JwtUtil jwtUtil;
+
+	@Test
+	@Transactional
+	@Rollback(false)
+	void tokenTest() {
+		Optional<User> userOpt = userRepository.findByOauth2Key("사용자 oauth2key 입력");
+
+		User user = userOpt.get();
+
+		jwtUtil.generateAccessToken(user.getOauth2Key(), user.getUuid());
+
+		Optional<String> accessTokenOpt = accessTokenRepository.findByUuid(user.getUuid());
+		Optional<String> refreshTokenOpt = refreshTokenRepository.findByUuid(user.getUuid());
+
+		String newAccessToken = jwtUtil.generateAccessToken(user.getOauth2Key(), user.getUuid());
+		String newRefreshToken = jwtUtil.generateRefreshToken(user.getUuid());
+
+		accessTokenRepository.save(user.getUuid(), newAccessToken);
+		refreshTokenRepository.save(user.getUuid(), newRefreshToken);
+	}
+
 }


### PR DESCRIPTION
  ## 🎯 작업 내용
  - 알림 설정 조회/업데이트 API 구현
  - 회원 가입 시 알림 설정 자동 초기화
  - AccessToken 및 RefreshToken 생성 테스트 코드 작성

  ## 📝 상세 설명
  사용자 알림 설정 관리 기능 추가:
  - GET /api/v1/alarm: 사용자의 알림 설정 조회
  - POST /api/v1/alarm: 알림 타입별 on/off 설정 업데이트
  - AlarmType:
    - WORKOUT_REPORT: 운동 리포트 알림 (필수, 기본값 true)
    - NEWS_AND_BENEFITS: 소식 및 혜택 알림 (선택, 기본값 false)
  - 회원가입 시 알림 타입별 기본값으로 알림 설정 자동 생성
  - Alarm 엔티티, Repository, Service 구현
  - ErrorCode에 ALARM_NOT_FOUND 추가
  - User-AlarmType 조합에 unique constraint 적용

  ## ✅ 테스트
  - [x] 회원가입 시 알림 설정 자동 생성 확인
  - [x] 알림 설정 조회 API 동작 확인
  - [x] 알림 설정 업데이트 API 동작 확인

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added alarm management system allowing users to view and configure notification preferences
  * Users can enable or disable workout reports and news/benefits notifications
  * Alarms are automatically initialized when a new account is created
  * New API endpoints to retrieve all alarms and update alarm settings

* **Error Handling**
  * Added error response for missing alarm configurations

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->