### PR TITLE
Feat: 일일 집계 시스템 구현

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -81,6 +81,7 @@ jobs:
               --name zone2be-app \
               --network zone2be_network \
               -p 8080:8080 \
+              -e TZ=Asia/Seoul \
               -e SPRING_PROFILES_ACTIVE=prod \
               -e DB_URL="${{ secrets.DB_URL }}" \
               -e DB_USERNAME="${{ secrets.DB_USERNAME }}" \

--- a/src/main/java/com/prography/zone_2_be/Zone2BeApplication.java
+++ b/src/main/java/com/prography/zone_2_be/Zone2BeApplication.java
@@ -3,11 +3,12 @@ package com.prography.zone_2_be;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.autoconfigure.security.servlet.UserDetailsServiceAutoConfiguration;
-
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication(exclude = UserDetailsServiceAutoConfiguration.class)
+@EnableScheduling
 public class Zone2BeApplication {
-    public static void main(String[] args) {
-        SpringApplication.run(Zone2BeApplication.class, args);
-    }
+	public static void main(String[] args) {
+		SpringApplication.run(Zone2BeApplication.class, args);
+	}
 }

--- a/src/main/java/com/prography/zone_2_be/domain/auth/dto/UserRegisterRequest.java
+++ b/src/main/java/com/prography/zone_2_be/domain/auth/dto/UserRegisterRequest.java
@@ -4,14 +4,17 @@ import java.time.LocalDate;
 import java.util.List;
 
 import com.prography.zone_2_be.domain.term.agreement.dto.TermAgreementSaveRequest;
+import com.prography.zone_2_be.domain.user.device.dto.request.UserDeviceSaveRequest;
 import com.prography.zone_2_be.domain.user.entity.Gender;
 
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Past;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 
 @Getter
+@AllArgsConstructor
 public class UserRegisterRequest {
 	@NotNull(message = "registrationId 필수 입력값입니다.")
 	public String registrationId;
@@ -29,4 +32,7 @@ public class UserRegisterRequest {
 
 	@Valid
 	private List<TermAgreementSaveRequest> termAgreementSaveRequests;
+
+	private UserDeviceSaveRequest userDeviceSaveRequest;
+
 }

--- a/src/main/java/com/prography/zone_2_be/domain/auth/service/AuthService.java
+++ b/src/main/java/com/prography/zone_2_be/domain/auth/service/AuthService.java
@@ -27,6 +27,7 @@ import com.prography.zone_2_be.domain.auth.exception.OAuth2LoadException;
 import com.prography.zone_2_be.domain.auth.repository.AccessTokenRepository;
 import com.prography.zone_2_be.domain.auth.repository.RefreshTokenRepository;
 import com.prography.zone_2_be.domain.term.agreement.service.TermAgreementService;
+import com.prography.zone_2_be.domain.user.entity.Provider;
 import com.prography.zone_2_be.domain.user.entity.User;
 import com.prography.zone_2_be.domain.user.exception.UserNotFoundException;
 import com.prography.zone_2_be.domain.user.repository.UserRepository;
@@ -114,7 +115,7 @@ public class AuthService {
 			throw new CustomException(ErrorCode.ALREADY_USER_EXISTS);
 		}
 
-		User newUser = User.forRegister(request, oauth2Key);
+		User newUser = User.forRegister(request, oauth2Key, Provider.from(request.getRegistrationId()));
 
 		return userRepository.save(newUser);
 	}
@@ -160,12 +161,13 @@ public class AuthService {
 
 		ClientRegistration registration =
 			clientRegistrationRepository.findByRegistrationId(registrationId);
+
 		if (registration == null) {
 			throw new IllegalArgumentException("Unknown OAuth provider: " + registrationId);
 		}
 
 		//TODO: 리팩 토링
-		if ("apple".equals(registrationId)) {
+		if (Provider.APPLE.getRegistrationId().equals(registrationId)) {
 			try {
 				JWTClaimsSet claims = JWTParser.parse(accessToken).getJWTClaimsSet();
 				return claims.getSubject();

--- a/src/main/java/com/prography/zone_2_be/domain/auth/service/AuthService.java
+++ b/src/main/java/com/prography/zone_2_be/domain/auth/service/AuthService.java
@@ -27,6 +27,7 @@ import com.prography.zone_2_be.domain.auth.exception.OAuth2LoadException;
 import com.prography.zone_2_be.domain.auth.repository.AccessTokenRepository;
 import com.prography.zone_2_be.domain.auth.repository.RefreshTokenRepository;
 import com.prography.zone_2_be.domain.term.agreement.service.TermAgreementService;
+import com.prography.zone_2_be.domain.user.device.service.UserDeviceService;
 import com.prography.zone_2_be.domain.user.entity.Provider;
 import com.prography.zone_2_be.domain.user.entity.User;
 import com.prography.zone_2_be.domain.user.exception.UserNotFoundException;
@@ -45,6 +46,7 @@ public class AuthService {
 
 	private final AlarmService alarmService;
 	private final TermAgreementService termAgreementService;
+	private final UserDeviceService userDeviceService;
 
 	private final UserRepository userRepository;
 	private final AccessTokenRepository accessTokenRepository;
@@ -66,6 +68,7 @@ public class AuthService {
 	public UserAuthResponse register(UserRegisterRequest request, String oauthToken) {
 		User user = createUser(request, oauthToken);
 
+		userDeviceService.save(user, request.getUserDeviceSaveRequest());
 		alarmService.initializeAlarmByUser(user);
 
 		String newAccessToken = createAccessToken(user);

--- a/src/main/java/com/prography/zone_2_be/domain/user/device/dto/request/UserDeviceSaveRequest.java
+++ b/src/main/java/com/prography/zone_2_be/domain/user/device/dto/request/UserDeviceSaveRequest.java
@@ -1,0 +1,18 @@
+package com.prography.zone_2_be.domain.user.device.dto.request;
+
+import com.prography.zone_2_be.domain.user.device.entity.OsType;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class UserDeviceSaveRequest {
+
+	private OsType osType;
+
+	private String deviceModel;
+}

--- a/src/main/java/com/prography/zone_2_be/domain/user/device/entity/OsType.java
+++ b/src/main/java/com/prography/zone_2_be/domain/user/device/entity/OsType.java
@@ -1,0 +1,13 @@
+package com.prography.zone_2_be.domain.user.device.entity;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum OsType {
+	ANDROID("android"),
+	IOS("ios");
+
+	private final String value;
+}

--- a/src/main/java/com/prography/zone_2_be/domain/user/device/entity/UserDevice.java
+++ b/src/main/java/com/prography/zone_2_be/domain/user/device/entity/UserDevice.java
@@ -1,0 +1,54 @@
+package com.prography.zone_2_be.domain.user.device.entity;
+
+import com.prography.zone_2_be.domain.user.entity.User;
+import com.prography.zone_2_be.global.entity.BaseEntity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.ConstraintMode;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.ForeignKey;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class UserDevice extends BaseEntity {
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(
+		name = "user_id",
+		nullable = false,
+		foreignKey = @ForeignKey(ConstraintMode.NO_CONSTRAINT)
+	)
+	private User user;
+
+	@Enumerated(EnumType.STRING)
+	@Column(nullable = false, length = 20)
+	private OsType osType;
+
+	@Column(length = 50)
+	private String deviceModel;
+
+	@Builder
+	private UserDevice(User user, OsType osType, String deviceModel) {
+		this.user = user;
+		this.osType = osType;
+		this.deviceModel = deviceModel;
+	}
+
+	public static UserDevice of(User user, OsType osType, String deviceModel) {
+		return UserDevice.builder()
+			.user(user)
+			.osType(osType)
+			.deviceModel(deviceModel)
+			.build();
+	}
+}

--- a/src/main/java/com/prography/zone_2_be/domain/user/device/repository/UserDeviceRepository.java
+++ b/src/main/java/com/prography/zone_2_be/domain/user/device/repository/UserDeviceRepository.java
@@ -1,0 +1,11 @@
+package com.prography.zone_2_be.domain.user.device.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import com.prography.zone_2_be.domain.user.device.entity.UserDevice;
+
+@Repository
+public interface UserDeviceRepository extends JpaRepository<UserDevice, Long> {
+
+}

--- a/src/main/java/com/prography/zone_2_be/domain/user/device/service/UserDeviceService.java
+++ b/src/main/java/com/prography/zone_2_be/domain/user/device/service/UserDeviceService.java
@@ -1,0 +1,27 @@
+package com.prography.zone_2_be.domain.user.device.service;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.prography.zone_2_be.domain.user.device.dto.request.UserDeviceSaveRequest;
+import com.prography.zone_2_be.domain.user.device.entity.UserDevice;
+import com.prography.zone_2_be.domain.user.device.repository.UserDeviceRepository;
+import com.prography.zone_2_be.domain.user.entity.User;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class UserDeviceService {
+
+	private final UserDeviceRepository userDeviceRepository;
+
+	@Transactional
+	public UserDevice save(User user, UserDeviceSaveRequest request) {
+
+		UserDevice userDevice = UserDevice.of(user, request.getOsType(), request.getDeviceModel());
+		
+		return userDeviceRepository.save(userDevice);
+	}
+
+}

--- a/src/main/java/com/prography/zone_2_be/domain/user/entity/Gender.java
+++ b/src/main/java/com/prography/zone_2_be/domain/user/entity/Gender.java
@@ -1,16 +1,14 @@
 package com.prography.zone_2_be.domain.user.entity;
 
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
 public enum Gender {
-    MALE(0),
-    FEMALE(1);
+	MALE(0),
+	FEMALE(1);
 
-    private final int value;
+	private final int value;
 
-    Gender(int value) {
-        this.value = value;
-    }
-
-    public int getValue() {
-        return this.value;
-    }
 }

--- a/src/main/java/com/prography/zone_2_be/domain/user/entity/Provider.java
+++ b/src/main/java/com/prography/zone_2_be/domain/user/entity/Provider.java
@@ -1,0 +1,31 @@
+package com.prography.zone_2_be.domain.user.entity;
+
+import java.util.Arrays;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum Provider {
+	KAKAO("kakao"),
+	NAVER("naver"),
+	GOOGLE("google"),
+	APPLE("apple");
+
+	private final String registrationId;
+
+	private static final Map<String, Provider> stringToEnum =
+		Arrays.stream(values())
+			.collect(Collectors.toMap(
+				Provider::getRegistrationId,
+				Function.identity()
+			));
+
+	public static Provider from(String registrationId) {
+		return stringToEnum.get(registrationId);
+	}
+}

--- a/src/main/java/com/prography/zone_2_be/domain/user/entity/Role.java
+++ b/src/main/java/com/prography/zone_2_be/domain/user/entity/Role.java
@@ -1,16 +1,14 @@
 package com.prography.zone_2_be.domain.user.entity;
 
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
 public enum Role {
-    ADMIN("admin"),
-    User("user");
+	ADMIN("admin"),
+	User("user");
 
-    private final String value;
+	private final String value;
 
-    Role(String value) {
-        this.value = value;
-    }
-
-    public String getValue() {
-        return this.value;
-    }
 }

--- a/src/main/java/com/prography/zone_2_be/domain/user/entity/User.java
+++ b/src/main/java/com/prography/zone_2_be/domain/user/entity/User.java
@@ -8,7 +8,6 @@ import java.util.UUID;
 
 import org.hibernate.annotations.SQLDelete;
 import org.hibernate.annotations.SQLRestriction;
-import org.hibernate.annotations.Where;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
@@ -33,6 +32,11 @@ import lombok.Setter;
 @SQLDelete(sql = "UPDATE user SET deleted_at = CURRENT_TIMESTAMP WHERE id = ?")
 @SQLRestriction("deleted_at IS NULL")
 public class User extends BaseEntity implements UserDetails {
+
+	@Column(updatable = false)
+	@Enumerated(EnumType.STRING)
+	private Provider provider;
+
 	@Column(nullable = false, updatable = false)
 	private String oauth2Key;
 
@@ -102,7 +106,9 @@ public class User extends BaseEntity implements UserDetails {
 	}
 
 	@Builder
-	public User(String oauth2Key, String uuid, Role role, LocalDate birth, Gender gender, Integer height, Integer weight) {
+	public User(Provider provider, String oauth2Key, String uuid, Role role, LocalDate birth, Gender gender,
+		Integer height, Integer weight) {
+		this.provider = provider;  // 추가
 		this.oauth2Key = oauth2Key;
 		this.role = role;// Default role is User
 		this.uuid = uuid;
@@ -118,9 +124,10 @@ public class User extends BaseEntity implements UserDetails {
 		}
 	}
 
-	public static User forRegister(UserRegisterRequest dto, String oauth2Key) {
+	public static User forRegister(UserRegisterRequest dto, String oauth2Key, Provider provider) {
 		return User.builder()
 			.oauth2Key(oauth2Key)
+			.provider(provider)
 			.role(Role.User) // Default role is User
 			.uuid(UUID.randomUUID().toString())
 			.birth(dto.birth)

--- a/src/main/java/com/prography/zone_2_be/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/prography/zone_2_be/domain/user/repository/UserRepository.java
@@ -1,15 +1,20 @@
 package com.prography.zone_2_be.domain.user.repository;
 
-import com.prography.zone_2_be.domain.user.entity.User;
+import java.time.Instant;
+import java.util.Optional;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
-import java.util.Optional;
+import com.prography.zone_2_be.domain.user.entity.User;
 
 @Repository
 public interface UserRepository extends JpaRepository<User, Long> {
-    Optional<User> findByOauth2Key(String Oauth2Key);
-    Optional<User> findByUuid(String uuid);
-    boolean existsByOauth2Key(String oAuth2Key);
+	Optional<User> findByOauth2Key(String Oauth2Key);
 
+	Optional<User> findByUuid(String uuid);
+
+	boolean existsByOauth2Key(String oAuth2Key);
+
+	long countByCreatedAtBetween(Instant start, Instant end);
 }

--- a/src/main/java/com/prography/zone_2_be/domain/user/service/UserService.java
+++ b/src/main/java/com/prography/zone_2_be/domain/user/service/UserService.java
@@ -1,5 +1,7 @@
 package com.prography.zone_2_be.domain.user.service;
 
+import java.time.Instant;
+
 import org.springframework.stereotype.Service;
 
 import com.prography.zone_2_be.domain.user.dto.UserFindResponse;
@@ -44,5 +46,9 @@ public class UserService {
 		User user = JwtUtil.getUser();
 		userRepository.delete(user);
 		log.info("사용자 {} 삭제됨", user.getUuid());
+	}
+
+	public long countByCreatedAtBetween(Instant start, Instant end) {
+		return userRepository.countByCreatedAtBetween(start, end);
 	}
 }

--- a/src/main/java/com/prography/zone_2_be/global/aspect/WorkoutCountingAspect.java
+++ b/src/main/java/com/prography/zone_2_be/global/aspect/WorkoutCountingAspect.java
@@ -1,0 +1,48 @@
+package com.prography.zone_2_be.global.aspect;
+
+import org.aspectj.lang.annotation.AfterReturning;
+import org.aspectj.lang.annotation.AfterThrowing;
+import org.aspectj.lang.annotation.Aspect;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Component;
+
+import com.prography.zone_2_be.global.error.ErrorCode;
+import com.prography.zone_2_be.global.exception.CustomException;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Aspect
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class WorkoutCountingAspect {
+
+	private static final String WORKOUT_SUCCESS_KEY = "workout:save:success";
+	private static final String WORKOUT_FAILURE_KEY = "workout:save:failure";
+
+	private final RedisTemplate<String, String> redisTemplate;
+
+	/**
+	 * saveWorkout 메서드가 정상 반환되면 성공 카운트 증가
+	 */
+	@AfterReturning("execution(* com.prography.zone_2_be.domain.workout.service.WorkoutService.saveWorkout(..))")
+	public void countSuccess() {
+		redisTemplate.opsForValue().increment(WORKOUT_SUCCESS_KEY);
+	}
+
+	/**
+	 * saveWorkout 메서드에서 CustomException 발생 시 실패 카운트 증가
+	 */
+	@AfterThrowing(
+		pointcut = "execution(* com.prography.zone_2_be.domain.workout.service.WorkoutService.saveWorkout(..))",
+		throwing = "ex"
+	)
+	public void countFailure(CustomException ex) {
+		if (ex.getErrorCode() == ErrorCode.WORKOUT_REQUIREMENTS_NOT_MET) {
+			redisTemplate.opsForValue().increment(WORKOUT_FAILURE_KEY);
+		}
+	}
+}
+
+

--- a/src/main/java/com/prography/zone_2_be/global/scheduler/DailyStatisticsScheduler.java
+++ b/src/main/java/com/prography/zone_2_be/global/scheduler/DailyStatisticsScheduler.java
@@ -1,0 +1,85 @@
+package com.prography.zone_2_be.global.scheduler;
+
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.ZoneId;
+
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.prography.zone_2_be.domain.user.service.UserService;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class DailyStatisticsScheduler {
+
+	private static final String WORKOUT_SUCCESS_KEY = "workout:save:success";
+	private static final String WORKOUT_FAILURE_KEY = "workout:save:failure";
+
+	private static final String DAILY_STATS_KEY_PREFIX = "daily_stats:";
+
+	private final UserService userService;
+	private final RedisTemplate<String, String> redisTemplate;
+
+	/**
+	 * 일일 통계 수집 및 저장
+	 */
+	@Scheduled(cron = "00 58 23 * * *")
+	@Transactional
+	public void getDailyStatistics() {
+		LocalDate targetDate = LocalDate.now();
+
+		// 1. 데이터 집계
+		Long workoutSuccessCount = getRedisCount(WORKOUT_SUCCESS_KEY);
+		Long workoutFailureCount = getRedisCount(WORKOUT_FAILURE_KEY);
+		Long userRegistrationCount = countUserRegistrationsByDate(targetDate);
+
+		// 2. 로그 출력
+		log.info("=============================================================================");
+		log.info("서비스 활성도 추적 {}: 운동 리포트 저장 성공: {}, 운동 리포트 저장 실패: {}, 회원가입: {}",
+			targetDate, workoutSuccessCount, workoutFailureCount, userRegistrationCount);
+		log.info("=============================================================================");
+
+		String dailyKey = DAILY_STATS_KEY_PREFIX + targetDate;
+
+		redisTemplate.opsForHash().put(dailyKey, "운동 리포트 저장 성공", String.valueOf(workoutSuccessCount));
+		redisTemplate.opsForHash().put(dailyKey, "운동 리포트 저장 실패", String.valueOf(workoutFailureCount));
+		redisTemplate.opsForHash().put(dailyKey, "회원가입", String.valueOf(userRegistrationCount));
+
+		// 4. 기존 카운터 초기화
+		resetRedisCounters();
+	}
+
+	/**
+	 * Redis에서 카운트 조회 (값이 없으면 0 반환)
+	 */
+	private Long getRedisCount(String key) {
+		String value = redisTemplate.opsForValue().get(key);
+		return value != null ? Long.parseLong(value) : 0L;
+	}
+
+	/**
+	 * 당일 회원가입 수 조회
+	 */
+	private Long countUserRegistrationsByDate(LocalDate date) {
+		Instant startOfDay = date.atStartOfDay(ZoneId.systemDefault()).toInstant();
+		Instant endOfDay = date.plusDays(1).atStartOfDay(ZoneId.systemDefault()).toInstant();
+
+		return userService.countByCreatedAtBetween(startOfDay, endOfDay);
+	}
+
+	/**
+	 * Redis 카운터 초기화
+	 */
+	private void resetRedisCounters() {
+		redisTemplate.delete(WORKOUT_SUCCESS_KEY);
+		redisTemplate.delete(WORKOUT_FAILURE_KEY);
+	}
+}
+


### PR DESCRIPTION
## 🎯 작업 내용
- 소셜로그인 플랫폼 컬럼 추가
- AOP 기반 운동 저장 성공/실패 카운팅 구현
- 매일 23:55 일일 통계 집계 스케줄러 추가
- 회원가입 수 조회 메서드 추가 (UserRepository, UserService)
- Docker 컨테이너 타임존 Asia/Seoul 설정

## 📝 상세 설명
GA 연동 전까지 임시로 사용할 통계 수집 시스템입니다.
- **WorkoutCountingAspect**: 운동 저장 성공/실패 시 Redis 카운터 증가
- **DailyStatisticsScheduler**: 매일 23:55에 통계 집계 후 Redis Hash에 저장하고 카운터 초기화
- **Redis 키**: `workout:save:success`, `workout:save:failure`, `daily_stats:{날짜}`

## ✅ 테스트
- 운동 저장 API 호출 후 Redis 카운터 증가 확인
- 스케줄러 실행 시각 확인 (23:55 KST)
- Redis에 일일 통계 저장 확인
- 타임존 설정 확인

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Device information is now captured during user registration, including operating system type and device model
  * Daily workout statistics are automatically collected and aggregated for performance tracking
  * User registration counts are tracked by date

* **Chores**
  * Updated production deployment timezone configuration to Asia/Seoul

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->