### PR TITLE
Feat : 설문조사 조회 및 참여 기능 추가

### DIFF
--- a/src/main/java/com/prography/zone_2_be/domain/survey/controller/SurveyController.java
+++ b/src/main/java/com/prography/zone_2_be/domain/survey/controller/SurveyController.java
@@ -1,0 +1,39 @@
+package com.prography.zone_2_be.domain.survey.controller;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.prography.zone_2_be.domain.survey.dto.SurveyEligibilityResponse;
+import com.prography.zone_2_be.domain.survey.dto.SurveyFindResponse;
+import com.prography.zone_2_be.domain.survey.service.SurveyService;
+import com.prography.zone_2_be.global.response.ApiResponse;
+
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/survey")
+public class SurveyController {
+
+	private final SurveyService surveyService;
+
+	@GetMapping("/eligibility")
+	public ResponseEntity<ApiResponse<SurveyEligibilityResponse>> checkSurveyEligibility() {
+		return ApiResponse.success(surveyService.checkSurveyEligibility());
+	}
+
+	@GetMapping
+	public ResponseEntity<ApiResponse<SurveyFindResponse>> findActiveSurvey() {
+		return ApiResponse.success(surveyService.findActiveSurvey());
+	}
+
+	@PostMapping("/{surveyId}/participate")
+	public ResponseEntity<ApiResponse<Void>> participate(@PathVariable Long surveyId) {
+		surveyService.participateSurvey(surveyId);
+		return ApiResponse.success();
+	}
+}

--- a/src/main/java/com/prography/zone_2_be/domain/survey/dto/SurveyEligibilityResponse.java
+++ b/src/main/java/com/prography/zone_2_be/domain/survey/dto/SurveyEligibilityResponse.java
@@ -1,0 +1,24 @@
+package com.prography.zone_2_be.domain.survey.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class SurveyEligibilityResponse {
+
+	@JsonProperty("isEligible")
+	private boolean eligible;
+
+	@Builder
+	private SurveyEligibilityResponse(boolean eligible) {
+		this.eligible = eligible;
+	}
+
+	public static SurveyEligibilityResponse of(boolean eligible) {
+		return SurveyEligibilityResponse.builder()
+			.eligible(eligible)
+			.build();
+	}
+}

--- a/src/main/java/com/prography/zone_2_be/domain/survey/dto/SurveyFindResponse.java
+++ b/src/main/java/com/prography/zone_2_be/domain/survey/dto/SurveyFindResponse.java
@@ -1,0 +1,35 @@
+package com.prography.zone_2_be.domain.survey.dto;
+
+import com.prography.zone_2_be.domain.survey.entity.Survey;
+
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class SurveyFindResponse {
+
+	private Long id;
+	private String title;
+	private String content;
+	private String url;
+
+	@Builder(access = AccessLevel.PRIVATE)
+	private SurveyFindResponse(Long id, String title, String content, String url) {
+		this.id = id;
+		this.title = title;
+		this.content = content;
+		this.url = url;
+	}
+
+	public static SurveyFindResponse from(Survey survey) {
+		return SurveyFindResponse.builder()
+			.id(survey.getId())
+			.title(survey.getTitle())
+			.content(survey.getContent())
+			.url(survey.getUrl())
+			.build();
+	}
+}

--- a/src/main/java/com/prography/zone_2_be/domain/survey/entity/Survey.java
+++ b/src/main/java/com/prography/zone_2_be/domain/survey/entity/Survey.java
@@ -1,0 +1,50 @@
+package com.prography.zone_2_be.domain.survey.entity;
+
+import java.time.Instant;
+
+import com.prography.zone_2_be.global.entity.BaseEntity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Survey extends BaseEntity {
+
+	@Column(nullable = false)
+	private String url;
+
+	@Column(nullable = false)
+	private String title;
+
+	@Column
+	private String content;
+
+	@Column(nullable = false)
+	private boolean active;
+
+	@Column
+	private Instant deletedAt;
+
+	@Builder
+	private Survey(String url, String title, String content, boolean active) {
+		this.url = url;
+		this.title = title;
+		this.content = content;
+		this.active = active;
+	}
+
+	public static Survey of(String url, String title, String content, boolean active) {
+		return Survey.builder()
+			.url(url)
+			.title(title)
+			.content(content)
+			.active(active)
+			.build();
+	}
+}

--- a/src/main/java/com/prography/zone_2_be/domain/survey/entity/UserSurveyParticipation.java
+++ b/src/main/java/com/prography/zone_2_be/domain/survey/entity/UserSurveyParticipation.java
@@ -1,0 +1,45 @@
+package com.prography.zone_2_be.domain.survey.entity;
+
+import com.prography.zone_2_be.domain.user.entity.User;
+import com.prography.zone_2_be.global.entity.BaseEntity;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(uniqueConstraints = {
+	@UniqueConstraint(columnNames = {"user_id", "survey_id"})
+})
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class UserSurveyParticipation extends BaseEntity {
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "user_id", nullable = false)
+	private User user;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "survey_id", nullable = false)
+	private Survey survey;
+
+	@Builder
+	private UserSurveyParticipation(User user, Survey survey) {
+		this.user = user;
+		this.survey = survey;
+	}
+
+	public static UserSurveyParticipation of(User user, Survey survey) {
+		return UserSurveyParticipation.builder()
+			.user(user)
+			.survey(survey)
+			.build();
+	}
+}

--- a/src/main/java/com/prography/zone_2_be/domain/survey/repository/SurveyRepository.java
+++ b/src/main/java/com/prography/zone_2_be/domain/survey/repository/SurveyRepository.java
@@ -1,0 +1,15 @@
+package com.prography.zone_2_be.domain.survey.repository;
+
+import java.util.Optional;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import com.prography.zone_2_be.domain.survey.entity.Survey;
+
+@Repository
+public interface SurveyRepository extends JpaRepository<Survey, Long> {
+	Optional<Survey> findByActiveTrue();
+
+	Optional<Survey> findByIdAndActiveTrue(Long id);
+}

--- a/src/main/java/com/prography/zone_2_be/domain/survey/repository/UserSurveyParticipationRepository.java
+++ b/src/main/java/com/prography/zone_2_be/domain/survey/repository/UserSurveyParticipationRepository.java
@@ -1,0 +1,13 @@
+package com.prography.zone_2_be.domain.survey.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import com.prography.zone_2_be.domain.survey.entity.Survey;
+import com.prography.zone_2_be.domain.survey.entity.UserSurveyParticipation;
+import com.prography.zone_2_be.domain.user.entity.User;
+
+@Repository
+public interface UserSurveyParticipationRepository extends JpaRepository<UserSurveyParticipation, Long> {
+	boolean existsByUserAndSurvey(User user, Survey survey);
+}

--- a/src/main/java/com/prography/zone_2_be/domain/survey/service/SurveyService.java
+++ b/src/main/java/com/prography/zone_2_be/domain/survey/service/SurveyService.java
@@ -1,0 +1,71 @@
+package com.prography.zone_2_be.domain.survey.service;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.prography.zone_2_be.domain.survey.dto.SurveyEligibilityResponse;
+import com.prography.zone_2_be.domain.survey.dto.SurveyFindResponse;
+import com.prography.zone_2_be.domain.survey.entity.Survey;
+import com.prography.zone_2_be.domain.survey.entity.UserSurveyParticipation;
+import com.prography.zone_2_be.domain.survey.repository.SurveyRepository;
+import com.prography.zone_2_be.domain.survey.repository.UserSurveyParticipationRepository;
+import com.prography.zone_2_be.domain.user.entity.User;
+import com.prography.zone_2_be.domain.workout.service.WorkoutService;
+import com.prography.zone_2_be.global.error.ErrorCode;
+import com.prography.zone_2_be.global.exception.CustomException;
+import com.prography.zone_2_be.global.utils.JwtUtil;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class SurveyService {
+
+	private final SurveyRepository surveyRepository;
+	private final UserSurveyParticipationRepository userSurveyParticipationRepository;
+	private final WorkoutService workoutService;
+
+	public SurveyEligibilityResponse checkSurveyEligibility() {
+		User user = JwtUtil.getUser();
+
+		Survey activeSurvey = surveyRepository.findByActiveTrue().orElse(null);
+		if (activeSurvey == null) {
+			return SurveyEligibilityResponse.of(false);
+		}
+
+		if (userSurveyParticipationRepository.existsByUserAndSurvey(user, activeSurvey)) {
+			return SurveyEligibilityResponse.of(false);
+		}
+
+		return SurveyEligibilityResponse.of(isEligibleWorkoutCount(user));
+	}
+
+	public SurveyFindResponse findActiveSurvey() {
+		Survey activeSurvey = surveyRepository.findByActiveTrue()
+			.orElseThrow(() -> new CustomException(ErrorCode.SURVEY_NOT_FOUND));
+		return SurveyFindResponse.from(activeSurvey);
+	}
+
+	@Transactional
+	public void participateSurvey(Long surveyId) {
+		User user = JwtUtil.getUser();
+
+		Survey survey = surveyRepository.findByIdAndActiveTrue(surveyId)
+			.orElseThrow(() -> new CustomException(ErrorCode.SURVEY_NOT_FOUND));
+
+		if (userSurveyParticipationRepository.existsByUserAndSurvey(user, survey)) {
+			throw new CustomException(ErrorCode.SURVEY_ALREADY_RESPONDED);
+		}
+
+		if (!isEligibleWorkoutCount(user)) {
+			throw new CustomException(ErrorCode.SURVEY_NOT_ELIGIBLE);
+		}
+
+		userSurveyParticipationRepository.save(UserSurveyParticipation.of(user, survey));
+	}
+
+	private boolean isEligibleWorkoutCount(User user) {
+		long workoutCount = workoutService.countUserWorkouts(user);
+		return workoutCount == 2 || workoutCount == 6 || workoutCount == 10;
+	}
+}

--- a/src/main/java/com/prography/zone_2_be/domain/workout/repository/WorkoutRepository.java
+++ b/src/main/java/com/prography/zone_2_be/domain/workout/repository/WorkoutRepository.java
@@ -39,4 +39,6 @@ public interface WorkoutRepository extends JpaRepository<Workout, Long> {
 		@Param("endTime") Instant endTime);
 
 	Optional<Workout> findByUuid(String uuid);
+
+	long countByUser(User user);
 }

--- a/src/main/java/com/prography/zone_2_be/domain/workout/service/WorkoutService.java
+++ b/src/main/java/com/prography/zone_2_be/domain/workout/service/WorkoutService.java
@@ -14,7 +14,6 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.prography.zone_2_be.domain.user.entity.User;
-import com.prography.zone_2_be.domain.user.repository.UserRepository;
 import com.prography.zone_2_be.domain.workout.dto.FoodFigure;
 import com.prography.zone_2_be.domain.workout.dto.IWorkoutTotalDto;
 import com.prography.zone_2_be.domain.workout.dto.WorkoutGetFatUsageResponse;
@@ -36,7 +35,6 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class WorkoutService {
 	private final WorkoutRepository workoutRepository;
-	private final UserRepository userRepository;
 
 	private Integer getRelativeFatUsage(Integer kcalUsage) {
 		return (getZone2FatUsage(kcalUsage) - getZone4FatUsage(kcalUsage));
@@ -52,6 +50,10 @@ public class WorkoutService {
 
 	public WorkoutGetFatUsageResponse getFatUsage(Integer kcalUsage) {
 		return WorkoutGetFatUsageResponse.of(getRelativeFatUsage(kcalUsage));
+	}
+
+	public long countUserWorkouts(User user) {
+		return workoutRepository.countByUser(user);
 	}
 
 	public WorkoutGetHistoryResponse getWorkoutHistory(Long startTime, Long endTime, int page, int size) {

--- a/src/main/java/com/prography/zone_2_be/global/error/ErrorCode.java
+++ b/src/main/java/com/prography/zone_2_be/global/error/ErrorCode.java
@@ -37,6 +37,11 @@ public enum ErrorCode {
 	// Alarm 에러 4500번대
 	ALARM_NOT_FOUND(HttpStatus.NOT_FOUND, 4500, "해당 알림 설정을 찾을 수 없습니다."),
 
+	// Survey 에러 4600번대
+	SURVEY_NOT_FOUND(HttpStatus.NOT_FOUND, 4600, "진행 중인 설문조사를 찾을 수 없습니다."),
+	SURVEY_ALREADY_RESPONDED(HttpStatus.BAD_REQUEST, 4601, "이미 참여한 설문조사입니다."),
+	SURVEY_NOT_ELIGIBLE(HttpStatus.BAD_REQUEST, 4602, "설문조사 참여 대상이 아닙니다."),
+
 	// Global Server 에러
 	DEFAULT_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, 5000, "서버에서 알 수 없는 오류 발생.");
 


### PR DESCRIPTION
## 🎯 작업 내용
- 설문조사 도메인 추가 (entity, dto, repository, service, controller)
- 활성 설문조사 조회 API 추가
- 설문조사 참여 가능 여부 조회 API 추가
- 설문조사 참여 기록 저장 API 추가
- 운동 기록 수 조회를 위해 WorkoutService에 사용자 운동 기록 카운트 메서드 추가

## 📝 상세 설명
활성화된 설문조사를 조회하고, 사용자의 설문조사 참여 가능 여부를 확인한 뒤 참여 이력을 저장할 수 있도록 구현했습니다.

- **Survey**: 설문조사 URL, 제목, 내용, 활성화 여부 관리
- **UserSurveyParticipation**: 사용자별 설문조사 참여 이력 저장
- **SurveyService**: 활성 설문 조회, 참여 가능 여부 확인, 참여 기록 저장 처리
- **참여 가능 조건**: 저장된 운동 기록 수가 2, 6, 10회 중 하나이고 현재 활성 설문조사에 참여 이력이 없는 사용자
- **참여 검증**: 참여 저장 시 활성 설문 여부, 중복 참여 여부, 운동 기록 수 조건을 재검증
- **중복 방지**: `user_id`, `survey_id` unique 제약 추가

## ✅ 테스트
- 활성 설문조사 조회 API 응답 확인
- 설문조사 참여 가능 여부 조회 API 응답 확인
- 운동 기록 수가 조건에 맞지 않는 사용자 참여 차단 확인
- 운동 기록 수가 2회인 사용자 참여 성공 확인
- 참여 후 참여 가능 여부가 false로 변경되는지 확인
- 동일 설문조사 중복 참여 요청 시 에러 응답 확인
- 인증 없이 설문조사 API 요청 시 401 응답 확인

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added survey system with eligibility checking based on workout history
  * Users can view active survey details and content
  * Survey participation is restricted to eligible users and prevents duplicate responses
  * New error handling for missing surveys, ineligible users, and duplicate participation attempts

<!-- end of auto-generated comment: release notes by coderabbit.ai -->